### PR TITLE
(api) update document types table

### DIFF
--- a/api/app/Http/Controllers/DocumentController.php
+++ b/api/app/Http/Controllers/DocumentController.php
@@ -166,16 +166,8 @@ class DocumentController extends Controller
         //
     }
 
-    public function generatePDF($document, $isCopy, $loggedInUserId){
-        $views = [
-            1 => 'res-dec-disp', //if document type == resolucion
-            2 => 'res-dec-disp', //if document type == declaracion
-            3 => 'res-dec-disp', //if document type == disposicion
-            4 => 'acta', //if document type == acta
-            5 => 'memo', //if document type == memo
-            6 => 'nota', //if document type == nota
-        ];        
-        $html = view($views[$document->documentType->id])->with([
+    public function generatePDF($document, $isCopy, $loggedInUserId){      
+        $html = view($document->documentType->view)->with([
             'document' => $document, 
             'isCopy' => $isCopy, 
             'anexos' => Anexo::with(['file'])->where('document_id', $document->id)->get()
@@ -303,18 +295,10 @@ class DocumentController extends Controller
 
     public function exportAnexo(Request $request, $id){
         $document = Document::where('id', $id)->first();
-        $views = [
-            1 => 'res-dec-disp', //if document type == resolucion
-            2 => 'res-dec-disp', //if document type == declaracion
-            3 => 'res-dec-disp', //if document type == disposicion
-            4 => 'nota', //if document type == nota
-            5 => 'acta', //if document type == acta
-            6 => 'memo', //if document type == memo
-        ];
         $html = "";
         if($document) {
             $filename = $document->name;
-            $html = view($views[$document->documentType->id])->with(['document' => $document, 'isCopy' => true, 'anexos' => Anexo::with(['file'])->where('document_id', $id)->get()]);
+            $html = view($document->documentType->view)->with(['document' => $document, 'isCopy' => true, 'anexos' => Anexo::with(['file'])->where('document_id', $id)->get()]);
         } 
         return $html;
         /*$snappdf = new \Beganovich\Snappdf\Snappdf();

--- a/api/app/Models/DocumentType.php
+++ b/api/app/Models/DocumentType.php
@@ -14,8 +14,12 @@ class DocumentType extends Model
     //protected $primaryKey = 'document_type_id';
 
     protected $fillable = [
-        'description'
+        'description',
+        'view',
+        'actionInOperativeSection'
     ];
+
+    protected $hidden = ['view', 'actionInOperativeSection'];
 
 
     //hasMany

--- a/api/database/migrations/2023_09_25_134735_alter_document_types_table.php
+++ b/api/database/migrations/2023_09_25_134735_alter_document_types_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('document_types', function (Blueprint $table) {
+            $table->string('view')->default('');
+            $table->string('actionInOperativeSection')->nullable();          
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 
 class DatabaseSeeder extends Seeder
 {
+
     /**
      * Seed the application's database.
      *
@@ -26,26 +27,38 @@ class DatabaseSeeder extends Seeder
             [
                 'id' => 1,
                 'description' => 'Resolución',
+                'view' => 'res-dec-disp',
+                'actionInOperativeSection' => 'resuelve'
             ],
             [
                 'id' => 2,
                 'description' => 'Declaración',
+                'view' => 'res-dec-disp',
+                'actionInOperativeSection' => 'declara'
             ],
             [
                 'id' => 3,
                 'description' => 'Disposición',
+                'view' => 'res-dec-disp',
+                'actionInOperativeSection' => 'dispone'
             ],
             [
                 'id' => 4,
                 'description' => 'Acta',
+                'view' => 'acta',
+                'actionInOperativeSection' => ''
             ],
             [
                 'id' => 5,
                 'description' => 'Memo',
+                'view' => 'memo',
+                'actionInOperativeSection' => ''
             ],
             [
                 'id' => 6,
                 'description' => 'Nota',
+                'view' => 'nota',
+                'actionInOperativeSection' => ''
             ],
         ]);
     }


### PR DESCRIPTION
* Add the following columns to 'document_types' table: view (name of the template that is used at pdf generation), 
actionInOperativeSection (action that appears in operative section, for example 'resuelve' in documents of type 'resolucion')

* Update 'document_types' table seeder, to assign values to 'view' and 'actionInOperativeSection' columns

*  Update DocumentController: at document generation, fetch template name from document_type model