### PR TITLE
(api) Add 'code' attribute to 'issuers' table

### DIFF
--- a/api/app/Http/Controllers/IssuerController.php
+++ b/api/app/Http/Controllers/IssuerController.php
@@ -131,7 +131,8 @@ class IssuerController extends Controller
             'province' => 'sometimes|string|nullable',
             'city' => 'sometimes|string|nullable',
             'website_url' => 'sometimes|string|nullable',
-            'email' => 'sometimes|string|nullable'
+            'email' => 'sometimes|string|nullable',
+            'code' => 'sometimes|string|nullable'
         ], [
             'required' => 'El campo :attribute es requerido',
             'numeric' => 'El campo :attribute debe ser un número',
@@ -145,6 +146,7 @@ class IssuerController extends Controller
             'province' => '"Provincia"',
             'website_url' => '"Url al sitio web"',
             'email' => '"Dirección de correo electrónico"',
+            'code' => '"Código"',
         ])->stopOnFirstFailure(true);
         $validator->validate();
         return $validator->validated();

--- a/api/app/Models/Issuer.php
+++ b/api/app/Models/Issuer.php
@@ -18,7 +18,8 @@ class Issuer extends Model
         'province',
         'website_url',
         'address',
-        'postal_code'
+        'postal_code',
+        'code'
     ];
 
     public function documents(){

--- a/api/database/migrations/2023_08_01_140243_update_issuers_table.php
+++ b/api/database/migrations/2023_08_01_140243_update_issuers_table.php
@@ -20,7 +20,9 @@ return new class extends Migration
             $table->string('address')->nullable();
             $table->string('postal_code')->nullable();        
             $table->string('province')->nullable();
-            $table->string('website_url')->nullable();    
+            $table->string('website_url')->nullable();
+            $table->string('code')->nullable();
+                
         });
     }
 


### PR DESCRIPTION
Add 'code' attribute to 'issuers' table. It´s value should be a short string that helps people to recognize the issuer (e.g the issuer acronym), and will be part of the number of the documents of that issuer.