### PR TITLE
(api) Add columns to 'documents' table

### DIFF
--- a/api/app/Models/Document.php
+++ b/api/app/Models/Document.php
@@ -20,10 +20,11 @@ class Document extends Model
         'destinatary',
         'subject',
         'ad_referendum',
-        'number'
-        
+        'number',
+        'operative_section_beginning_id',
+        'document_copy_stamp_id'
     ];
-
+    
     public function documentCopy(){
         return $this->hasOne(DocumentCopy::class);
     }

--- a/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
+++ b/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('documents', function (Blueprint $table) {
+            $table->bigInteger('operative_section_beginning_id')->unsigned();
+            $table->foreign('operative_section_beginning_id')->references('id')->on('operative_section_beginnings')->onDelete('cascade');
+            $table->bigInteger('document_copy_stamp_id')->nullable()->unsigned();
+            $table->foreign('document_copy_stamp_id')->references('id')->on('stamps')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('documents', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
Add the following columns to 'documents' table: 'operative_section_beginning_id' and 'document_copy_stamp_id'