### PR TITLE
(api) Add column 'heading_id' to 'documents' table

### DIFF
--- a/api/app/Models/Document.php
+++ b/api/app/Models/Document.php
@@ -22,7 +22,8 @@ class Document extends Model
         'ad_referendum',
         'number',
         'operative_section_beginning_id',
-        'true_copy_stamp_id'
+        'true_copy_stamp_id', 
+        'heading_id'
     ];
     
     public function documentCopy(){
@@ -49,6 +50,10 @@ class Document extends Model
 
     public function trueCopyStamp(){
         return $this->belongsTo(Stamp::class);
+    }
+
+    public function heading(){
+        return $this->belongsTo(Heading::class);
     }
 
     /*public function anexosSectionType(){

--- a/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
+++ b/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
@@ -18,6 +18,8 @@ return new class extends Migration
             $table->foreign('operative_section_beginning_id')->references('id')->on('operative_section_beginnings')->onDelete('cascade');
             $table->bigInteger('true_copy_stamp_id')->nullable()->unsigned();
             $table->foreign('true_copy_stamp_id')->references('id')->on('stamps')->onDelete('cascade');
+            $table->bigInteger('heading_id')->nullable()->unsigned();
+            $table->foreign('heading_id')->references('id')->on('headings');
         });
     }
 


### PR DESCRIPTION
* Add column 'heading_id' to 'documents' table, which is a foreign key to 'headings' table. 
* Add method 'heading' to Document model that retrieves the heading of a document 