### PR TITLE
(api) Add column 'heading_id' to 'issuer_settings' table

### DIFF
--- a/api/app/Models/IssuerSettings.php
+++ b/api/app/Models/IssuerSettings.php
@@ -33,6 +33,10 @@ class IssuerSettings extends Model
     public function trueCopyStamp(){
         return $this->belongsTo(Stamp::class);
     }
+    
+    public function heading(){
+        return $this->belongsTo(Heading::class);
+    }
 
     public function set($data){
         foreach ($data as $key => $value) {

--- a/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
+++ b/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
@@ -24,6 +24,8 @@ return new class extends Migration
             $table->foreign('true_copy_stamp_id')->references('id')->on('stamps')->onDelete('cascade');
             $table->bigInteger('issuer_id')->unsigned();
             $table->foreign('issuer_id')->references('id')->on('issuers')->onDelete('cascade');
+            $table->bigInteger('heading_id')->nullable()->unsigned();
+            $table->foreign('heading_id')->references('id')->on('headings');
         });
     }
 


### PR DESCRIPTION
* Add column 'heading_id' to 'issuer_settings' table, which is a foreign key to 'headings' table. This column represents the id of the most recent heading of the issuer whose id given by the column 'issuer_id'

* Add method 'heading' to IssuerSettings model that retrieves the  most recent heading of an issuer 