### PR TITLE
(api) Add column 'has_anexo_unico' to 'documents' table

### DIFF
--- a/api/app/Http/Controllers/DocumentController.php
+++ b/api/app/Http/Controllers/DocumentController.php
@@ -252,13 +252,15 @@ class DocumentController extends Controller
                 'ad_referendum' => 'sometimes|boolean|nullable',
                 'body' => 'required',
                 'subject' => 'sometimes|nullable|string',
-                'destinatary' => 'sometimes|nullable|string'
+                'destinatary' => 'sometimes|nullable|string',
+                'has_anexo_unico' => 'sometimes|boolean'
                 //'anexosSectionTypeId' => 'required'
             ], [
                 'required' => 'El campo :attribute es requerido',
                 'numeric' => 'El campo :attribute debe ser un número',
                 'date' => 'El campo :attribute debe ser una fecha en formato dd/mm/yyyy',
                 'string' => 'El campo :attribute debe ser de tipo string',
+                'boolean' => 'El campo :attribute debe ser de tipo booleano'
             ], [
                 'document_type_id' => '"tipo de documento"',
                 'name' => '"nombre de documento"',
@@ -268,6 +270,7 @@ class DocumentController extends Controller
                 'ad_referendum' => '"ad referendum"',
                 'subject' => '"Asunto"',
                 'destinatary' => '"Destinatario"',
+                'has_anexo_unico' => '"Tiene anexo único"'
                 //'anexosSectionTypeId' => '"tipo de anexo"'
             ])->stopOnFirstFailure(true);
         $validator->validate();
@@ -302,7 +305,7 @@ class DocumentController extends Controller
             'adReferendum' => $data->ad_referendum,
             'subject' => $data->subject,
             'destinatary' => $data->destinatary,
-            //'anexosSectionTypeId' => $data->anexos_section_type_id,
+            'hasAnexoUnico' => $data->has_anexo_unico,
             'body' => json_decode($data->body),
             'anexos' => Anexo::with(['file'])->where('document_id', $data->id)->get()
         ];

--- a/api/app/Models/Document.php
+++ b/api/app/Models/Document.php
@@ -23,7 +23,8 @@ class Document extends Model
         'number',
         'operative_section_beginning_id',
         'true_copy_stamp_id', 
-        'heading_id'
+        'heading_id',
+        'has_anexo_unico'
     ];
     
     public function documentCopy(){

--- a/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
+++ b/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->foreign('true_copy_stamp_id')->references('id')->on('stamps');
             $table->bigInteger('heading_id')->nullable()->unsigned();
             $table->foreign('heading_id')->references('id')->on('headings');
+            $table->boolean('has_anexo_unico')->default(false);
         });
     }
 


### PR DESCRIPTION
Add new column to 'documents' table: 'has_anexo_unico'. This column stores a boolean value, if it's true it indicates that the document has an 'anexo' of type 'unico'. Otherwise, it means that the document have 'anexos' of type 'numbered' or that it does not have any 'anexo' at all 