### PR TITLE
(api) Alter 'issuer_settings' table

### DIFF
--- a/api/app/Http/Controllers/IssuerSettingsController.php
+++ b/api/app/Http/Controllers/IssuerSettingsController.php
@@ -159,7 +159,7 @@ class IssuerSettingsController extends Controller
         $validator = Validator::make($request->all(), [
             'issuer_id' => 'required|numeric|exists:issuers,id',
             'suggested_operative_section_beginning_id' => 'required|numeric|exists:operative_section_beginnings,id',
-            'true_copy_stamp_id' => 'sometimes|numeric|exists:stamps,id',
+            'suggested_true_copy_stamp_id' => 'sometimes|numeric|exists:stamps,id',
             'suggested_heading_id' => 'required|numeric|exists:headings,id',
 
         ], [
@@ -168,7 +168,7 @@ class IssuerSettingsController extends Controller
         ], [
             'issuer_id' => '"Emisor"',
             'suggested_operative_section_beginning_id' => '"Inicio de sección operativa sugerido"',
-            'true_copy_stamp_id' => '"Sello en copia fiel"',
+            'suggested_true_copy_stamp_id' => '"Sello en copia fiel sugerido"',
             'suggested_heading_id' => '"Membrete sugerido"',
         ])->stopOnFirstFailure(true);
         $validator->validate();

--- a/api/app/Http/Controllers/IssuerSettingsController.php
+++ b/api/app/Http/Controllers/IssuerSettingsController.php
@@ -158,14 +158,14 @@ class IssuerSettingsController extends Controller
     private function validateRequest($request){
         $validator = Validator::make($request->all(), [
             'issuer_id' => 'required|numeric|exists:issuers,id',
-            'operative_section_beginning_id' => 'required|numeric|exists:operative_section_beginnings,id',
+            'suggested_operative_section_beginning_id' => 'required|numeric|exists:operative_section_beginnings,id',
             'true_copy_stamp_id' => 'sometimes|numeric|exists:stamps,id'
         ], [
             'required' => 'El campo :attribute es requerido',
             'numeric' => 'El campo :attribute debe ser un número'
         ], [
             'issuer_id' => '"Emisor"',
-            'operative_section_beginning_id' => '"Inicio de sección operativa"',
+            'suggested_operative_section_beginning_id' => '"Inicio de sección operativa sugerido"',
             'true_copy_stamp_id' => '"Sello en copia fiel"'
         ])->stopOnFirstFailure(true);
         $validator->validate();

--- a/api/app/Http/Controllers/IssuerSettingsController.php
+++ b/api/app/Http/Controllers/IssuerSettingsController.php
@@ -159,14 +159,17 @@ class IssuerSettingsController extends Controller
         $validator = Validator::make($request->all(), [
             'issuer_id' => 'required|numeric|exists:issuers,id',
             'suggested_operative_section_beginning_id' => 'required|numeric|exists:operative_section_beginnings,id',
-            'true_copy_stamp_id' => 'sometimes|numeric|exists:stamps,id'
+            'true_copy_stamp_id' => 'sometimes|numeric|exists:stamps,id',
+            'suggested_heading_id' => 'required|numeric|exists:headings,id',
+
         ], [
             'required' => 'El campo :attribute es requerido',
             'numeric' => 'El campo :attribute debe ser un número'
         ], [
             'issuer_id' => '"Emisor"',
             'suggested_operative_section_beginning_id' => '"Inicio de sección operativa sugerido"',
-            'true_copy_stamp_id' => '"Sello en copia fiel"'
+            'true_copy_stamp_id' => '"Sello en copia fiel"',
+            'suggested_heading_id' => '"Membrete sugerido"',
         ])->stopOnFirstFailure(true);
         $validator->validate();
         return $validator->validated();

--- a/api/app/Http/Controllers/IssuerSettingsController.php
+++ b/api/app/Http/Controllers/IssuerSettingsController.php
@@ -18,7 +18,7 @@ class IssuerSettingsController extends Controller
     {
         try {    
             if($request->has('issuer_id')){
-                $results = IssuerSettings::where('issuer_id', $request->query('issuer_id'))->get();
+                $results = IssuerSettings::where('issuer_id', $request->query('issuer_id'))->first();
             } else {
                 $results = IssuerSettings::all();
             }
@@ -159,7 +159,6 @@ class IssuerSettingsController extends Controller
         $validator = Validator::make($request->all(), [
             'issuer_id' => 'required|numeric|exists:issuers,id',
             'operative_section_beginning_id' => 'required|numeric|exists:operative_section_beginnings,id',
-            'ad_referendum_operative_section_beginning_id' => 'sometimes|numeric|exists:operative_section_beginnings,id',
             'true_copy_stamp_id' => 'sometimes|numeric|exists:stamps,id'
         ], [
             'required' => 'El campo :attribute es requerido',
@@ -167,7 +166,6 @@ class IssuerSettingsController extends Controller
         ], [
             'issuer_id' => '"Emisor"',
             'operative_section_beginning_id' => '"Inicio de sección operativa"',
-            'ad_referendum_operative_section_beginning_id' => '"Inicio de sección operativa en documentos Ad-referendum"',
             'true_copy_stamp_id' => '"Sello en copia fiel"'
         ])->stopOnFirstFailure(true);
         $validator->validate();

--- a/api/app/Models/IssuerSettings.php
+++ b/api/app/Models/IssuerSettings.php
@@ -13,7 +13,6 @@ class IssuerSettings extends Model
 
     protected $fillable = [
         'operative_section_beginning_id',
-        'ad_referendum_operative_section_beginning_id',
         'true_copy_stamp_id',
         'issuer_id'
     ];
@@ -24,10 +23,6 @@ class IssuerSettings extends Model
 
     public function operativeSectionBeginning(){
         return $this->belongsTo(OperativeSectionBeginning::class);
-    }
-
-    public function adReferendumOperativeSectionBeginning(){
-        return $this->belongsTo(OperativeSectionBeginning::class, 'ad_ref_operative_section_beginning_id');
     }
 
     public function trueCopyStamp(){

--- a/api/app/Models/IssuerSettings.php
+++ b/api/app/Models/IssuerSettings.php
@@ -14,7 +14,8 @@ class IssuerSettings extends Model
     protected $fillable = [
         'suggested_operative_section_beginning_id',
         'true_copy_stamp_id',
-        'issuer_id'
+        'issuer_id',
+        'suggested_heading_id'
     ];
 
     public function issuer(){
@@ -29,7 +30,7 @@ class IssuerSettings extends Model
         return $this->belongsTo(Stamp::class);
     }
     
-    public function heading(){
+    public function suggestedHeading(){
         return $this->belongsTo(Heading::class);
     }
 

--- a/api/app/Models/IssuerSettings.php
+++ b/api/app/Models/IssuerSettings.php
@@ -13,7 +13,7 @@ class IssuerSettings extends Model
 
     protected $fillable = [
         'suggested_operative_section_beginning_id',
-        'true_copy_stamp_id',
+        'suggested_true_copy_stamp_id',
         'issuer_id',
         'suggested_heading_id'
     ];
@@ -26,7 +26,7 @@ class IssuerSettings extends Model
         return $this->belongsTo(OperativeSectionBeginning::class);
     }
 
-    public function trueCopyStamp(){
+    public function suggestedTrueCopyStamp(){
         return $this->belongsTo(Stamp::class);
     }
     

--- a/api/app/Models/IssuerSettings.php
+++ b/api/app/Models/IssuerSettings.php
@@ -12,7 +12,7 @@ class IssuerSettings extends Model
     protected $table = 'issuer_settings';
 
     protected $fillable = [
-        'operative_section_beginning_id',
+        'suggested_operative_section_beginning_id',
         'true_copy_stamp_id',
         'issuer_id'
     ];
@@ -21,7 +21,7 @@ class IssuerSettings extends Model
         return $this->belongsTo(Issuer::class);
     }
 
-    public function operativeSectionBeginning(){
+    public function suggestedOperativeSectionBeginning(){
         return $this->belongsTo(OperativeSectionBeginning::class);
     }
 

--- a/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
+++ b/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
@@ -18,8 +18,8 @@ return new class extends Migration
             $table->timestamps();
             $table->bigInteger('suggested_operative_section_beginning_id')->unsigned();
             $table->foreign('suggested_operative_section_beginning_id')->references('id')->on('operative_section_beginnings');
-            $table->bigInteger('true_copy_stamp_id')->nullable()->unsigned();
-            $table->foreign('true_copy_stamp_id')->references('id')->on('stamps');
+            $table->bigInteger('suggested_true_copy_stamp_id')->nullable()->unsigned();
+            $table->foreign('suggested_true_copy_stamp_id')->references('id')->on('stamps');
             $table->bigInteger('issuer_id')->unsigned();
             $table->foreign('issuer_id')->references('id')->on('issuers');
             $table->bigInteger('suggested_heading_id')->nullable()->unsigned();

--- a/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
+++ b/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
@@ -18,8 +18,6 @@ return new class extends Migration
             $table->timestamps();
             $table->bigInteger('operative_section_beginning_id')->unsigned();
             $table->foreign('operative_section_beginning_id')->references('id')->on('operative_section_beginnings');
-            $table->bigInteger('ad_ref_operative_section_beginning_id')->nullable()->unsigned();
-            $table->foreign('ad_ref_operative_section_beginning_id')->references('id')->on('operative_section_beginnings');
             $table->bigInteger('true_copy_stamp_id')->nullable()->unsigned();
             $table->foreign('true_copy_stamp_id')->references('id')->on('stamps');
             $table->bigInteger('issuer_id')->unsigned();

--- a/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
+++ b/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
@@ -22,8 +22,8 @@ return new class extends Migration
             $table->foreign('true_copy_stamp_id')->references('id')->on('stamps');
             $table->bigInteger('issuer_id')->unsigned();
             $table->foreign('issuer_id')->references('id')->on('issuers');
-            $table->bigInteger('heading_id')->nullable()->unsigned();
-            $table->foreign('heading_id')->references('id')->on('headings');
+            $table->bigInteger('suggested_heading_id')->nullable()->unsigned();
+            $table->foreign('suggested_heading_id')->references('id')->on('headings');
         });
     }
 

--- a/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
+++ b/api/database/migrations/2023_08_03_121822_create_issuer_settings_table.php
@@ -16,8 +16,8 @@ return new class extends Migration
         Schema::create('issuer_settings', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
-            $table->bigInteger('operative_section_beginning_id')->unsigned();
-            $table->foreign('operative_section_beginning_id')->references('id')->on('operative_section_beginnings');
+            $table->bigInteger('suggested_operative_section_beginning_id')->unsigned();
+            $table->foreign('suggested_operative_section_beginning_id')->references('id')->on('operative_section_beginnings');
             $table->bigInteger('true_copy_stamp_id')->nullable()->unsigned();
             $table->foreign('true_copy_stamp_id')->references('id')->on('stamps');
             $table->bigInteger('issuer_id')->unsigned();


### PR DESCRIPTION
This pull request makes the following changes in 'issuer_settings' table:
* removes 'ad_ref_operative_section_beginning_id' column 
* rename 'operative_section_beginning_id' column to 'suggested_operative_section_beginning_id'
* rename 'heading_id' column to 'suggested_heading_id'
* rename 'true_copy_stamp_id' column to 'suggested_true_copy_stamp_id'