### PR TITLE
(api) Add relationship between stamp and user who uploads it - remove relationship between stamp and issuer

### DIFF
--- a/api/app/Http/Controllers/StampController.php
+++ b/api/app/Http/Controllers/StampController.php
@@ -49,6 +49,7 @@ class StampController extends Controller
     public function store(Request $request)
     {
         $validatedData = $this->validateRequest($request);
+        array_push($validatedData, ['redacta_user_id' => $request->user()->id]);
         try {  
             $stamp = Stamp::create($validatedData);
             return response()->json([
@@ -156,7 +157,7 @@ class StampController extends Controller
         $validator = Validator::make($request->all(), [
             'full_name' => 'required|string',
             'position' => 'sometimes|string',
-            'issuer_id'=> $presence.'|numeric|exists:issuers,id'
+            'issuer_id'=> $presence.'|numeric|exists:issuers,id',
         ], [
             'required' => 'El campo :attribute es requerido',
             'string' => 'El campo :attribute debe ser un string',

--- a/api/app/Http/Controllers/StampController.php
+++ b/api/app/Http/Controllers/StampController.php
@@ -150,22 +150,15 @@ class StampController extends Controller
     }
 
     private function validateRequest($request){
-        $presence = 'required';
-        if ($request->isMethod('patch')) {
-            $presence = 'sometimes';
-        }
         $validator = Validator::make($request->all(), [
             'full_name' => 'required|string',
             'position' => 'sometimes|string',
-            'issuer_id'=> $presence.'|numeric|exists:issuers,id',
         ], [
             'required' => 'El campo :attribute es requerido',
             'string' => 'El campo :attribute debe ser un string',
-            'issuer_id.exists' => 'El emisor especificado no existe'
         ], [
             'full_name' => '"Nombre completo"',
             'position' => '"Cargo"',
-            'issuer_id' => '"Emisor"'
         ])->stopOnFirstFailure(true);
         $validator->validate();
         return $validator->validated();

--- a/api/app/Models/RedactaUser.php
+++ b/api/app/Models/RedactaUser.php
@@ -47,4 +47,9 @@ class RedactaUser extends Authenticatable
         return $this->hasMany(DocumentStateHistoryItem::class);
     }
 
+    public function stamps()
+    {
+        return $this->hasMany(Stamp::class);
+    }
+
 }

--- a/api/app/Models/Stamp.php
+++ b/api/app/Models/Stamp.php
@@ -13,6 +13,11 @@ class Stamp extends Model
     protected $fillable = [
         'full_name',
         'position',
-        'issuer_id'
+        'issuer_id',
+        'redacta_user_id'
     ];
+
+    public function redactaUser(){
+        return $this->belongsTo(RedactaUser::class);
+    }
 }

--- a/api/app/Models/Stamp.php
+++ b/api/app/Models/Stamp.php
@@ -13,7 +13,6 @@ class Stamp extends Model
     protected $fillable = [
         'full_name',
         'position',
-        'issuer_id',
         'redacta_user_id'
     ];
 

--- a/api/database/migrations/2023_08_03_121706_create_stamps_table.php
+++ b/api/database/migrations/2023_08_03_121706_create_stamps_table.php
@@ -20,6 +20,8 @@ return new class extends Migration
             $table->string('position')->nullable();
             $table->bigInteger('issuer_id')->unsigned();
             $table->foreign('issuer_id')->references('id')->on('issuers');
+            $table->bigInteger('redacta_user_id')->unsigned();
+            $table->foreign('redacta_user_id')->references('id')->on('redacta_users');
         });
 
         Schema::table('stamps', function (Blueprint $table) {

--- a/api/database/migrations/2023_08_03_121706_create_stamps_table.php
+++ b/api/database/migrations/2023_08_03_121706_create_stamps_table.php
@@ -18,8 +18,6 @@ return new class extends Migration
             $table->timestamps();
             $table->string('full_name');
             $table->string('position')->nullable();
-            $table->bigInteger('issuer_id')->unsigned();
-            $table->foreign('issuer_id')->references('id')->on('issuers');
             $table->bigInteger('redacta_user_id')->unsigned();
             $table->foreign('redacta_user_id')->references('id')->on('redacta_users');
         });


### PR DESCRIPTION
This pull request does the following:

* adds the column 'redacta_user_id' to 'stamps' table. This column stores the id of the user who uploaded a stamp. 
* adds the method 'stamps' to RedactaUser model (allows to fetch the stamps uploaded by a given user) 
* adds the method 'redactaUser' to Stamp model (given a stamp, this method allows to fetch the user who uploaded it).
* modify the method 'store' of StampController (the id of the user who made the incoming request is added to the data of the stamp that is about to be stored).
* removes the column 'issuer_id' from 'stamps' table

