### PR TITLE
(api) Add column 'description' to 'stamps' table

### DIFF
--- a/api/app/Http/Controllers/StampController.php
+++ b/api/app/Http/Controllers/StampController.php
@@ -153,12 +153,14 @@ class StampController extends Controller
         $validator = Validator::make($request->all(), [
             'full_name' => 'required|string',
             'position' => 'sometimes|string',
+            'description' => 'required|string',
         ], [
             'required' => 'El campo :attribute es requerido',
             'string' => 'El campo :attribute debe ser un string',
         ], [
             'full_name' => '"Nombre completo"',
             'position' => '"Cargo"',
+            'description' => '"Descripción"',
         ])->stopOnFirstFailure(true);
         $validator->validate();
         return $validator->validated();

--- a/api/app/Models/Stamp.php
+++ b/api/app/Models/Stamp.php
@@ -13,7 +13,8 @@ class Stamp extends Model
     protected $fillable = [
         'full_name',
         'position',
-        'redacta_user_id'
+        'redacta_user_id',
+        'description'
     ];
 
     public function redactaUser(){

--- a/api/database/migrations/2023_08_03_121706_create_stamps_table.php
+++ b/api/database/migrations/2023_08_03_121706_create_stamps_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->string('position')->nullable();
             $table->bigInteger('redacta_user_id')->unsigned();
             $table->foreign('redacta_user_id')->references('id')->on('redacta_users');
+            $table->string('description');
         });
 
         Schema::table('stamps', function (Blueprint $table) {


### PR DESCRIPTION
This pull request add a column named 'description' to 'stamps' table. This column stores a very short description of the stamps, which helps the users to identify each one of them.