### PR TITLE
(api) add Signature resource

### DIFF
--- a/api/app/Http/Controllers/SignatureController.php
+++ b/api/app/Http/Controllers/SignatureController.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Signature;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class SignatureController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+        
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $validatedData = $this->validateRequest($request);
+        array_push($validatedData, ['redacta_user_id' => $request->user()->id]);
+        try {  
+            $signature = Signature::create($validatedData);
+            return response()->json([
+                'status' => 201,
+                'message' => 'OK',
+                'data' => $signature         
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        try { 
+            $signature = Signature::find($id);
+            if(!$signature){
+                return response()->json([
+                    'status' => 404,
+                    'message' => 'El recurso al que desea acceder no existe'        
+                ], 404);
+            }
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $signature           
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+        
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        try {
+            $signature = Signature::find($id);
+            if (!$signature) {
+                return response()->json([
+                    'status' => 404,
+                    'message' => 'El recurso al que desea acceder no existe'        
+                ], 404);
+            }
+            $signature->delete();
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $signature           
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    private function validateRequest($request){
+        $validator = Validator::make($request->all(), [
+            'document_id' => 'required|numeric|exists:documents,id',
+            'stamp_id' => 'required|numeric|exists:stamps,id',
+        ], [
+            'required' => 'El campo :attribute es requerido',
+            'numeric' => 'El campo :attribute debe ser un número entero',
+        ], [
+            'document_id' => '"Documento"',
+            'stamp_id' => '"Sello"',
+        ])->stopOnFirstFailure(true);
+        $validator->validate();
+        return $validator->validated();
+    }
+}

--- a/api/app/Models/Document.php
+++ b/api/app/Models/Document.php
@@ -73,6 +73,10 @@ class Document extends Model
         return $this->hasMany(Anexo::class);
     }
 
+    public function signatures(){
+        return $this->hasMany(Signature::class);
+    }
+
     public function set($data){
         $issuer = Issuer::find($data['issuer_id']);
         $user = RedactaUser::find(Auth::id());

--- a/api/app/Models/Signature.php
+++ b/api/app/Models/Signature.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Signature extends Model
+{
+    use HasFactory;
+    protected $fillable = [
+        'document_id',
+        'redacta_user_id',
+        'stamp_id'
+    ];
+
+    public function document() {
+        return $this->belongsTo(Document::class);
+    }
+
+    public function redactaUser(){
+        return $this->belongsTo(RedactaUser::class);
+    }
+
+    public function stamp(){
+        return $this->belongsTo(Stamp::class);
+    }
+
+
+}

--- a/api/database/migrations/2024_01_17_192302_create_signatures_table.php
+++ b/api/database/migrations/2024_01_17_192302_create_signatures_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('signatures', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->bigInteger('document_id')->unsigned();
+            $table->foreign('document_id')->references('id')->on('documents');
+            $table->bigInteger('redacta_user_id')->unsigned();
+            $table->foreign('redacta_user_id')->references('id')->on('redacta_users');
+            $table->bigInteger('stamp_id')->unsigned();
+            $table->foreign('stamp_id')->references('id')->on('stamps');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('signatures');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\IssuerSettingsController;
 use App\Http\Controllers\HeadingController;
 use App\Http\Controllers\OperativeSectionBeginningController;
 use App\Http\Controllers\StampController;
+use App\Http\Controllers\SignatureController;
 
 
 /*
@@ -36,6 +37,7 @@ Route::middleware('auth:sanctum')->group(function () {
   Route::apiResource('issuers', IssuerController::class);
   Route::apiResource('operative_section_beginnings', OperativeSectionBeginningController::class);
   Route::apiResource('stamps', StampController::class);
+  Route::apiResource('signatures', SignatureController::class);
   Route::get('/export_anexo/{id}', [DocumentController::class, 'exportAnexo']);
 });
 


### PR DESCRIPTION
This pull request creates the Signature resource, which represents a signature of a certain document. This pull requests does the following:

* adds the 'Signature' model
* adds the 'SignatureController'
* adds the migration to create the 'signatures' table
* adds to 'Document' model a function that returns the signatures of a given document
* add the 'signatures' route to api routes file