### PR TITLE
(api) Modify stamps

### DIFF
--- a/api/app/Http/Controllers/StampController.php
+++ b/api/app/Http/Controllers/StampController.php
@@ -151,15 +151,13 @@ class StampController extends Controller
 
     private function validateRequest($request){
         $validator = Validator::make($request->all(), [
-            'full_name' => 'required|string',
-            'position' => 'sometimes|string',
+            'content' => 'required|string',
             'description' => 'required|string',
         ], [
             'required' => 'El campo :attribute es requerido',
             'string' => 'El campo :attribute debe ser un string',
         ], [
-            'full_name' => '"Nombre completo"',
-            'position' => '"Cargo"',
+            'content' => '"Contenido"',
             'description' => '"Descripción"',
         ])->stopOnFirstFailure(true);
         $validator->validate();

--- a/api/app/Models/Stamp.php
+++ b/api/app/Models/Stamp.php
@@ -11,8 +11,7 @@ class Stamp extends Model
     use HasFactory, SoftDeletes;
     
     protected $fillable = [
-        'full_name',
-        'position',
+        'content',
         'redacta_user_id',
         'description'
     ];

--- a/api/database/migrations/2023_08_03_121706_create_stamps_table.php
+++ b/api/database/migrations/2023_08_03_121706_create_stamps_table.php
@@ -16,8 +16,7 @@ return new class extends Migration
         Schema::create('stamps', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
-            $table->string('full_name');
-            $table->string('position')->nullable();
+            $table->text('content');
             $table->bigInteger('redacta_user_id')->unsigned();
             $table->foreign('redacta_user_id')->references('id')->on('redacta_users');
             $table->string('description');

--- a/api/public/assets/css/document.css
+++ b/api/public/assets/css/document.css
@@ -102,3 +102,8 @@ th, td {
 .signatures {
     height: 10rem;
 }
+
+.stamp p{
+    text-align: center;
+    line-height: 0.5rem;
+}

--- a/api/resources/views/res-dec-disp.blade.php
+++ b/api/resources/views/res-dec-disp.blade.php
@@ -100,10 +100,9 @@
 						<td class="document-footer-cell">
 							<p>ES COPIA FIEL</p>
 							<div style="display: flex; flex-flow: row-reverse;">
-								<p style="text-align: center">
-									Fdo. {{$document->trueCopyStamp->full_name}} <br>
-									{{$document->trueCopyStamp->position}}
-								</p>
+								<div class="stamp">
+									{!! $document->trueCopyStamp->content !!}
+								</div>
 							</div>
 						</td>
 						<td class="document-footer-empty-cell"></td>
@@ -115,10 +114,9 @@
 			<div class="footer">
 				<p>ES COPIA FIEL</p>
 				<div style="display: flex; flex-flow: row-reverse;">
-					<p style="text-align: center">
-						Fdo. {{$document->trueCopyStamp->full_name}} <br>
-						{{$document->trueCopyStamp->position}}
-					</p>
+					<div style="text-align: center">
+						{!! $document->trueCopyStamp->content !!}
+					</div>
 				</div>
 			</div>
 		@endif


### PR DESCRIPTION
This pull request does the following:
* Modify 'stamps' table: substitute 'full_name' and 'position' columns with 'content' column. This new column stores a html string which is the content of the stamp. This change increases the level of customization of the stamps.
* Updates documents templates and styles to display the stamps 'content'