### PR TITLE
(api) Add 'suggested_starting_phrase', 'suggested_parting_phrase' and 'suggested_operative_section_last_article' cols to 'issuers_settings' table

### DIFF
--- a/api/app/Models/IssuerSettings.php
+++ b/api/app/Models/IssuerSettings.php
@@ -15,7 +15,10 @@ class IssuerSettings extends Model
         'suggested_operative_section_beginning_id',
         'suggested_true_copy_stamp_id',
         'issuer_id',
-        'suggested_heading_id'
+        'suggested_heading_id',
+        'suggested_operative_section_last_article',
+        'suggested_starting_phrase',
+        'suggested_parting_phrase'
     ];
 
     public function issuer(){

--- a/api/database/migrations/2023_08_03_122800_create_issuer_settings_table.php
+++ b/api/database/migrations/2023_08_03_122800_create_issuer_settings_table.php
@@ -24,6 +24,9 @@ return new class extends Migration
             $table->foreign('issuer_id')->references('id')->on('issuers');
             $table->bigInteger('suggested_heading_id')->nullable()->unsigned();
             $table->foreign('suggested_heading_id')->references('id')->on('headings');
+            $table->string('suggested_operative_section_last_article')->nullable();
+            $table->string('suggested_starting_phrase')->nullable();
+            $table->string('suggested_parting_phrase')->nullable();
         });
     }
 


### PR DESCRIPTION
This pull request add the following cols to 'issuers_settings' table:

* suggested_starting_phrase
* suggested_parting_phrase
* suggested_operative_section_last_article

These new columns stores suggestions for the starting phrase and parting phrase (which are part of 'nota' documents) and for the last article of operative section (in the case of 'resolucion', 'declaracion' and 'disposicion' documents). 