### PR TITLE
(api) Add document shared access functionality

### DIFF
--- a/api/app/Http/Controllers/DocumentSharedAccessController.php
+++ b/api/app/Http/Controllers/DocumentSharedAccessController.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\DocumentSharedAccess;
+use App\Models\Document;
+use Illuminate\Support\Facades\Validator;
+
+
+class DocumentSharedAccessController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        try {       
+            if ($request->has('document_id')) {
+                if (!$this->userHasAccessToDocument($request->user()->id, Document::find($request->query('document_id')))) {
+                    return response()->json([
+                        'status' => 422,
+                        'message' => 'Documento inválido'        
+                    ], 422);
+                }
+                $result = DocumentSharedAccess::where('document_id', $request->query('document_id'))->get();
+            } else {
+                $result = $request->user()->documentsSharedAccesses;
+            }
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $result        
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $validatedData = $this->validateRequest($request);
+        try {
+            $document = Document::find($validatedData['document_id']);
+            if ($document->redactaUser->id != $request->user()->id) {
+                return response()->json([
+                    'status' => 422,
+                    'message' => 'Documento inválido'        
+                ], 422);
+            }
+            if ($this->userHasAccessToDocument($validatedData['redacta_user_id'], $document)) {
+                return response()->json([
+                    'status' => 409,
+                    'message' => 'La cuenta seleccionada ya tiene actualmente permisos de acceso a este documento'        
+                ], 409);
+            }
+            $documentSharedAccess = DocumentSharedAccess::create($validatedData);
+            return response()->json([
+                'status' => 201,
+                'message' => 'OK',
+                'data' => $documentSharedAccess           
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Request $request, $id)
+    {
+        try {
+            $documentSharedAccess = DocumentSharedAccess::find($id);
+            if (!$documentSharedAccess || 
+                !$this->userHasAccessToDocument($request->user()->id, $documentSharedAccess->document)) {
+                return response()->json([
+                    'status' => 404,
+                    'message' => 'Recurso inexistente'        
+                ], 404);
+            }
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $documentSharedAccess           
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Request $request, $id)
+    {
+        try { 
+            $documentSharedAccess = DocumentSharedAccess::find($id);
+            if (!$documentSharedAccess || 
+                ($documentSharedAccess->redactaUser->id != $request->user()->id &&
+                    $documentSharedAccess->document->redactaUser->id != $request->user()->id)) {
+                return response()->json([
+                    'status' => 404,
+                    'message' => 'Recurso inexistente'        
+                ], 404);
+            }
+            $documentSharedAccess->delete();
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $documentSharedAccess           
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    private function validateRequest($request) {
+        $validator = Validator::make($request->all(), [
+            'redacta_user_id' => 'required|numeric|exists:redacta_users,id',
+            'document_id' => 'required|numeric|exists:documents,id',
+        ], [
+            'required' => 'El campo :attribute es requerido',
+            'numeric' => 'El campo :attribute debe ser numérico',
+        ], [
+            'redacta_user_id' => '"Usuario"',
+            'document_id' => '"Documento"'
+        ])->stopOnFirstFailure(true);
+        $validator->validate();
+        return $validator->validated();
+    }
+
+    private function userHasAccessToDocument($loggedInUserId, $document) {
+        if ($document->redactaUser->id != $loggedInUserId) {
+            $documentSharedAccess = DocumentSharedAccess::where([
+                ['redacta_user_id', '=', $loggedInUserId],
+                ['document_id', '=', $document->id]
+            ])->get();
+            if (count($documentSharedAccess) == 0) {
+                return false;
+            }
+        }
+        return true; 
+    }
+}

--- a/api/app/Models/Document.php
+++ b/api/app/Models/Document.php
@@ -76,13 +76,17 @@ class Document extends Model
     public function signatures(){
         return $this->hasMany(Signature::class);
     }
-
+    
+    public function documentSharedAccesses(){
+        return $this->hasMany(DocumentSharedAccess::class);
+    }
+    
     public function set($data){
         $issuer = Issuer::find($data['issuer_id']);
-        $user = RedactaUser::find(Auth::id());
+        //$user = RedactaUser::find(Auth::id());
         $documentType = DocumentType::find($data['document_type_id']);
         //$anexosSectionType = AnexosSectionType::find($data['anexos_section_type_id']);        
-        $this->redactaUser()->associate($user);
+        //$this->redactaUser()->associate($user);
         
         foreach ($data as $key => $value) {
             if ($key == 'document_type_id'){

--- a/api/app/Models/DocumentSharedAccess.php
+++ b/api/app/Models/DocumentSharedAccess.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DocumentSharedAccess extends Model
+{
+    use HasFactory;
+    protected $table = 'documents_shared_accesses';
+    protected $with = ['redactaUser'];
+
+    protected $fillable = [
+        'document_id',
+        'redacta_user_id', 
+    ];
+
+    public function document(){
+        return $this->belongsTo(Document::class);
+    }
+
+    public function redactaUser(){
+        return $this->belongsTo(RedactaUser::class);
+    }
+
+
+
+}

--- a/api/app/Models/RedactaUser.php
+++ b/api/app/Models/RedactaUser.php
@@ -52,4 +52,9 @@ class RedactaUser extends Authenticatable
         return $this->hasMany(Stamp::class);
     }
 
+    public function documentsSharedAccesses()
+    {
+        return $this->hasMany(DocumentSharedAccess::class);
+    }
+
 }

--- a/api/database/migrations/2024_03_14_181334_create_documents_shared_accesses_table.php
+++ b/api/database/migrations/2024_03_14_181334_create_documents_shared_accesses_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('documents_shared_accesses', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->bigInteger('document_id')->unsigned();
+            $table->foreign('document_id')->references('id')->on('documents')->onDelete('cascade');
+            $table->bigInteger('redacta_user_id')->unsigned();
+            $table->foreign('redacta_user_id')->references('id')->on('redacta_users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('documents_shared_accesses');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\HeadingController;
 use App\Http\Controllers\OperativeSectionBeginningController;
 use App\Http\Controllers\StampController;
 use App\Http\Controllers\SignatureController;
+use App\Http\Controllers\DocumentSharedAccessingController;
 
 
 /*
@@ -38,6 +39,7 @@ Route::middleware('auth:sanctum')->group(function () {
   Route::apiResource('operative_section_beginnings', OperativeSectionBeginningController::class);
   Route::apiResource('stamps', StampController::class);
   Route::apiResource('signatures', SignatureController::class);
+  Route::apiResource('documents_shared_accessing', DocumentSharedAccessing::class);
   Route::get('/export_anexo/{id}', [DocumentController::class, 'exportAnexo']);
 });
 


### PR DESCRIPTION
This pull request implements the document sharing functionality. This allows a user to share their own documents with other users. A user that has been shared the access a document can do the following with it:
* edit its content
* add/remove signatures
* remove the access that has received

To implement this functionality. this pull request does the following:

* add the 'shared document access' resource
* add 'sharedDocumentAccesses' accessors to Document and RedactaUser models
* modify 'Anexo', 'Signature' and 'Document' controllers, adding validations to verify that the user who sends the request has access to the document (only if needed)