### PR TITLE
(front) add 'document shared access' page

### DIFF
--- a/frontend/src/app/document-editor/document-editor.component.html
+++ b/frontend/src/app/document-editor/document-editor.component.html
@@ -7,4 +7,7 @@
             <app-document-signatures></app-document-signatures>
         </ng-template>
     </nb-tab>
+    <nb-tab tabTitle="Acceso compartido" *ngIf="documentId" class="signatures-tab">
+        <app-document-shared-access></app-document-shared-access>
+    </nb-tab>
 </nb-tabset>  

--- a/frontend/src/app/document-editor/document-editor.component.scss
+++ b/frontend/src/app/document-editor/document-editor.component.scss
@@ -6,3 +6,8 @@ nb-tab {
     margin-top: 0;
     margin-bottom: 0;
 }
+
+nb-tabset {
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+}

--- a/frontend/src/app/document-editor/document-editor.module.ts
+++ b/frontend/src/app/document-editor/document-editor.module.ts
@@ -9,6 +9,7 @@ import { NbMomentDateModule } from '@nebular/moment';
 import { SharedModule } from '../shared/shared.module';
 import { DocumentContentModule } from './document-content/document-content.module';
 import { DocumentSignaturesModule } from './document-signatures/document-signatures.module';
+import { DocumentSharedAccessModule } from './document-shared-access/document-shared-access.module';
 
 
 
@@ -39,7 +40,8 @@ import { DocumentSignaturesModule } from './document-signatures/document-signatu
     SharedModule,
     NbTabsetModule,
     DocumentSignaturesModule,
-    DocumentContentModule
+    DocumentContentModule,
+    DocumentSharedAccessModule
   ]
 })
 export class DocumentEditorModule { }

--- a/frontend/src/app/document-editor/document-shared-access/document-shared-access.component.html
+++ b/frontend/src/app/document-editor/document-shared-access/document-shared-access.component.html
@@ -1,0 +1,51 @@
+<div class="h-100">
+    <nb-card class="h-100" *ngIf="viewState == 'loading'" [nbSpinner]="true" nbSpinnerStatus="primary">
+        <nb-card-body></nb-card-body>
+    </nb-card>
+    <div *ngIf="viewState == 'rendering'">
+        <div class="flex-container">
+            <div class="d-flex justify-content-end pb-2">
+                        <div class="d-flex align-items-center text-align-center">
+                            <div class="mr-2" nbTooltip="Añadir cuenta">
+                                <button class="ghost-btn" nbButton ghost (click)="addDocumentSharedAccess()">
+                                    <nb-icon icon="plus-outline" status="primary"></nb-icon>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+            <div class="scrollable">
+                <nb-card>
+                    <nb-card-header>
+                        Accesos compartidos a este documento 
+                    </nb-card-header>
+                    <nb-list>
+                        <nb-list-item *ngIf="documentSharedAccesses.length == 0">
+                            Este documento no tiene accesos compartidos
+                        </nb-list-item>
+                        <nb-list-item *ngFor="let sharedAccess of documentSharedAccesses; let i=index">
+                            <div class="w-100 d-flex flex-column">
+                                <div class="w-100 d-flex justify-content-between">
+                                    {{sharedAccess['redactaUser']['name']}} {{sharedAccess['redactaUser']['lastName']}}
+                                    <div class="d-flex">
+                                        <div class="mr-2" nbTooltip="Eliminar">
+                                            <button class="ghost-btn" nbButton ghost>
+                                                <nb-icon icon="close-outline" status="primary" (click)="removeDocumentSharedAccess(sharedAccess.id)"></nb-icon>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </nb-list-item>
+                    </nb-list>
+                </nb-card>
+            </div>
+        </div>
+        <!--div class="d-flex flex-column flex-sm-row">
+            <button nbButton (click)="export()" status="primary">Exportar original</button>
+            <button nbButton (click)="export(true)" status="primary" class="mt-3 mt-sm-0 ml-sm-3">Exportar copia fiel</button>
+        </div-->
+    </div>
+    <div *ngIf="viewState == 'error'">
+        Ha habido un problema al cargar las firmas de este documento. Intente recargar la página
+    </div>
+</div>

--- a/frontend/src/app/document-editor/document-shared-access/document-shared-access.component.scss
+++ b/frontend/src/app/document-editor/document-shared-access/document-shared-access.component.scss
@@ -1,0 +1,19 @@
+.buttons-container {
+    line-height: 3rem;
+}
+
+.flex-container {
+    flex: 1;
+    display: flex;
+    flex-flow: column;
+    height: calc(100vh - 12rem);
+}
+
+.scrollable {
+    overflow-y: auto;
+    flex-grow: 1; 
+}
+
+.scrollable nb-card:last-child {
+    margin-bottom: 0;
+}

--- a/frontend/src/app/document-editor/document-shared-access/document-shared-access.component.spec.ts
+++ b/frontend/src/app/document-editor/document-shared-access/document-shared-access.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DocumentSharedAccessComponent } from './document-shared-access.component';
+
+describe('DocumentSharedAccessComponent', () => {
+  let component: DocumentSharedAccessComponent;
+  let fixture: ComponentFixture<DocumentSharedAccessComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DocumentSharedAccessComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DocumentSharedAccessComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/document-editor/document-shared-access/document-shared-access.component.ts
+++ b/frontend/src/app/document-editor/document-shared-access/document-shared-access.component.ts
@@ -1,0 +1,89 @@
+import { Component, OnInit } from '@angular/core';
+import { NbDialogService } from '@nebular/theme';
+import { ApiConnectionService } from '../../api-connection.service';
+import { ActivatedRoute } from '@angular/router';
+import { DocumentService } from '../../shared/document.service';
+import { finalize } from 'rxjs';
+import { ErrorHandlerService } from 'src/app/shared/error-handler/error-handler.service';
+import { UserSelectorComponent } from './user-selector/user-selector.component';
+
+@Component({
+  selector: 'app-document-shared-access',
+  templateUrl: './document-shared-access.component.html',
+  styleUrls: ['./document-shared-access.component.scss']
+})
+export class DocumentSharedAccessComponent implements OnInit {
+
+  //@Input('documentId') 
+  documentId: any;
+  viewState = '';
+  documentDocumentSharedAccesss: any = [];
+  exportOptions = [
+    { title: 'Exportar original' }, 
+    { title: 'Exportar copia fiel' }
+  ];
+  documentSharedAccesses: any;
+
+
+  constructor(private dialogService: NbDialogService,
+              private connectionService: ApiConnectionService,
+              private route: ActivatedRoute,
+              private documentService: DocumentService,
+              private errorHandler: ErrorHandlerService) { }
+
+
+  ngOnInit(): void {
+    this.route.queryParams.subscribe(params => {this.documentId = params['id']});
+    if(this.documentId){
+      this.viewState = 'loading';
+      this.getDocumentSharedAccesss();
+    }
+  }
+
+  addDocumentSharedAccess() {
+    this.dialogService.open(UserSelectorComponent, {context: {documentId: this.documentId}}).onClose.subscribe(status => {
+      if(status){
+        this.getDocumentSharedAccesss();
+      }
+    });
+  }
+
+  removeDocumentSharedAccess(documentSharedAccessId: any) {
+    this.viewState = 'loading';
+    this.connectionService.delete('documents_shared_accesses', documentSharedAccessId).subscribe({
+      next: _ => {
+        this.getDocumentSharedAccesss();
+      },
+      error: e => {
+        this.viewState = '';
+        this.errorHandler.handle(e);
+      }
+    });  
+  }
+
+  getDocumentSharedAccesss(){
+    this.connectionService.get('documents_shared_accesses?document_id=' + this.documentId).subscribe({
+      next: (res: any) => {
+        this.documentSharedAccesses = res.data;
+        this.viewState = 'rendering';
+      },
+      error: e => {
+        this.viewState = 'error';
+      }
+    });
+  }
+
+  
+
+  export(trueCopy = false){
+    this.viewState = 'loading';
+    this.documentService.exportDocument(this.documentId, trueCopy)
+      .pipe(finalize(()=> this.viewState = 'rendering'))
+      .subscribe({
+        error: _ => {
+          this.errorHandler.handle();
+        }
+      })
+  }
+
+}

--- a/frontend/src/app/document-editor/document-shared-access/document-shared-access.module.ts
+++ b/frontend/src/app/document-editor/document-shared-access/document-shared-access.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NbButtonModule, NbCardModule, NbContextMenuModule, NbDialogModule, NbIconModule, NbInputModule, NbListModule, NbSelectModule, NbSpinnerModule, NbTooltipModule } from '@nebular/theme';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared.module';
+import { DocumentSharedAccessComponent } from './document-shared-access.component';
+import { UserSelectorComponent } from './user-selector/user-selector.component';
+
+
+
+@NgModule({
+  declarations: [
+    DocumentSharedAccessComponent,
+    UserSelectorComponent
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    NbInputModule,
+    NbCardModule,
+    NbButtonModule,
+    NbSelectModule,
+    NbIconModule,
+    NbSpinnerModule,
+    NbDialogModule.forChild(),
+    NbListModule,
+    SharedModule,
+    NbTooltipModule,
+    NbContextMenuModule,
+  ],
+  exports: [
+    DocumentSharedAccessComponent
+  ]
+})
+export class DocumentSharedAccessModule { }

--- a/frontend/src/app/document-editor/document-shared-access/user-selector/user-selector.component.html
+++ b/frontend/src/app/document-editor/document-shared-access/user-selector/user-selector.component.html
@@ -1,0 +1,15 @@
+<nb-card class="h-100" *ngIf="viewState == 'loading'" [nbSpinner]="true" nbSpinnerStatus="primary">
+    <nb-card-body></nb-card-body>
+  </nb-card>
+<nb-card class="h-100" *ngIf="viewState == 'rendering'">
+    <nb-card-header>Agregar acceso compartido</nb-card-header>
+    <nb-card-body>
+        <nb-select fullWidth placeholder="Seleccionar cuenta" [formControl]="userIdFormControl">
+            <nb-option *ngFor="let user of users" [value]="user.id">{{user.name}} {{user.lastName}}</nb-option>
+        </nb-select>
+    </nb-card-body>
+    <nb-card-footer>
+        <button nbButton status="primary" (click)="submit()" class="mr-4">Guardar</button>
+        <button nbButton (click)="cancel()">Cancelar</button>
+    </nb-card-footer>
+</nb-card>

--- a/frontend/src/app/document-editor/document-shared-access/user-selector/user-selector.component.spec.ts
+++ b/frontend/src/app/document-editor/document-shared-access/user-selector/user-selector.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserSelectorComponent } from './user-selector.component';
+
+describe('UserSelectorComponent', () => {
+  let component: UserSelectorComponent;
+  let fixture: ComponentFixture<UserSelectorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ UserSelectorComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserSelectorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/document-editor/document-shared-access/user-selector/user-selector.component.ts
+++ b/frontend/src/app/document-editor/document-shared-access/user-selector/user-selector.component.ts
@@ -1,0 +1,74 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import { NbDialogRef } from '@nebular/theme';
+import { finalize, forkJoin } from 'rxjs';
+import { ApiConnectionService } from 'src/app/api-connection.service';
+import { ErrorHandlerService } from 'src/app/shared/error-handler/error-handler.service';
+
+@Component({
+  selector: 'app-user-selector',
+  templateUrl: './user-selector.component.html',
+  styleUrls: ['./user-selector.component.scss']
+})
+export class UserSelectorComponent implements OnInit {
+
+  users: any [] = [];
+  form!: FormGroup;
+  documentId: any;
+  viewState = 'loading';
+
+  constructor(private connectionService: ApiConnectionService,
+    protected dialogRef: NbDialogRef<UserSelectorComponent>,
+    private fb: FormBuilder,
+    private errorHandler: ErrorHandlerService) { }
+ 
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      documentId: this.fb.control(''),
+      redactaUserId: this.fb.control('')
+    });
+    let requests = [this.connectionService.get('redacta_users')];
+    this.form.get('documentId')?.setValue(this.documentId);
+    
+    forkJoin(requests)
+      .pipe(finalize(() => {this.viewState = 'rendering'}))
+      .subscribe({
+        next: (res: any) => {
+          this.users = res[0].data;
+          if(res.length > 1){
+            this.form.get('redactaUserId')?.setValue(res[1].data.redactaUserId);
+            this.form.get('documentId')?.setValue(res[1].data.documentId);
+          }
+        },
+        error: e => {
+          this.errorHandler.handle(e);
+          this.cancel();
+        }
+      });
+  }
+
+  get userIdFormControl(){
+    return this.form.get('redactaUserId') as FormControl;
+  }
+
+  submit(){
+    let request;
+    this.viewState = 'loading';
+    request = this.connectionService.post('documents_shared_accesses', this.form.value);
+    request
+      .pipe(finalize(() => {this.viewState = 'rendering'}))
+      .subscribe({
+        next: _ => {
+          this.dialogRef.close(true);
+        },
+        error: e => {
+          this.errorHandler.handle(e);
+        }
+      })
+  }
+
+  cancel(){
+    this.dialogRef.close(false);
+  }
+
+}


### PR DESCRIPTION
This pull request adds the 'document shared access' section to the document editor. From this section, a user can: 
* conceed access to the current document to other users (only if the former is the creator of the document)
* remove condeded accesses to the current document
* see the conceded accesses to the current document