### PR TITLE
(api) Add 'visibility level' resource

### DIFF
--- a/api/app/Http/Controllers/VisibilityLevelController.php
+++ b/api/app/Http/Controllers/VisibilityLevelController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\VisibilityLevel;
+use Illuminate\Http\Request;
+
+class VisibilityLevelController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        try {    
+            $results = VisibilityLevel::all();
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $results           
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        try { 
+            $visibilityLevel = VisibilityLevel::find($id);
+            if (!$visibilityLevel) {
+                return response()->json([
+                    'status' => 404,
+                    'message' => 'Recurso inexistente'        
+                ], 404);
+            }
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $visibilityLevel          
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\VisibilityLevel  $visibilityLevel
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(VisibilityLevel $visibilityLevel)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Models\VisibilityLevel  $visibilityLevel
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, VisibilityLevel $visibilityLevel)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\VisibilityLevel  $visibilityLevel
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(VisibilityLevel $visibilityLevel)
+    {
+        //
+    }
+}

--- a/api/app/Models/Document.php
+++ b/api/app/Models/Document.php
@@ -55,6 +55,10 @@ class Document extends Model
         return $this->belongsTo(Heading::class);
     }
 
+    public function visibilityLevel(){
+        return $this->belongsTo(VisibilityLevel::class);
+    }
+
     /*public function anexosSectionType(){
         return $this->belongsTo(AnexosSectionType::class);
     }*/

--- a/api/app/Models/VisibilityLevel.php
+++ b/api/app/Models/VisibilityLevel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class VisibilityLevel extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'label'
+    ];
+}

--- a/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
+++ b/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
@@ -21,6 +21,8 @@ return new class extends Migration
             $table->bigInteger('heading_id')->nullable()->unsigned();
             $table->foreign('heading_id')->references('id')->on('headings');
             $table->boolean('has_anexo_unico')->default(false);
+            $table->bigInteger('visibility_level_id')->nullable()->unsigned();
+            $table->foreign('visibility_level_id')->references('id')->on('visibility_levels');
         });
     }
 

--- a/api/database/migrations/2024_04_30_122741_create_visibility_levels_table.php
+++ b/api/database/migrations/2024_04_30_122741_create_visibility_levels_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('visibility_levels', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->string('name');
+            $table->string('label');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('visibility_levels');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\StampController;
 use App\Http\Controllers\SignatureController;
 use App\Http\Controllers\DocumentSharedAccessController;
 use App\Http\Controllers\RedactaUserController;
+use App\Http\Controllers\VisibilityLevelController;
 
 
 /*
@@ -42,8 +43,9 @@ Route::middleware('auth:sanctum')->group(function () {
   Route::apiResource('signatures', SignatureController::class);
   Route::apiResource('documents_shared_accesses', DocumentSharedAccessController::class);
   Route::apiResource('redacta_users', RedactaUserController::class);
-  Route::get('/export_anexo/{id}', [DocumentController::class, 'exportAnexo']);
+  Route::apiResource('visibility_levels', VisibilityLevelController::class);
 });
+Route::get('/export_anexo/{id}', [DocumentController::class, 'exportAnexo']);
 
 
 


### PR DESCRIPTION
This pull request adds the 'visibility level' resource, which represents the visibility level of a given document. These levels are: 
* private (only its creator and the users that have shared access to the document can access it)
* internal (all the members of the organization can access the document)
* public (anyone can access the document)