### PR TITLE
(api) Add column 'stamps' to 'documents' table

### DIFF
--- a/api/app/Http/Controllers/DocumentController.php
+++ b/api/app/Http/Controllers/DocumentController.php
@@ -52,11 +52,14 @@ class DocumentController extends Controller
     {
         $data = $this->validateRequest($request, 'post');
         try {
-            if(!isset($data['true_copy_stamp_id'])){
+            if (!isset($data['true_copy_stamp_id'])) {
                 $issuerSettings = Issuer::find($data['issuer_id'])->issuerSettings;
                 if (isset($issuerSettings->suggestedTrueCopyStamp)) {
                     $data['true_copy_stamp_id'] = $issuerSettings->suggestedTrueCopyStamp->id;
                 }
+            }
+            if (isset($data['stamps'])) {
+                $data['stamps'] = json_encode( $data['stamps']);
             }
             $data['redacta_user_id'] = $request->user()->id;
             $document = new Document();
@@ -65,6 +68,11 @@ class DocumentController extends Controller
             $document->anexos = Anexo::with(['file'])->where('document_id', $document->id)->orderBy('index', 'ASC')->get();
             $document->signatures = Signature::with(['stamp'])->where('document_id', $document->id)->get();
             $document->body = json_decode($document->body);
+            if ($document->stamps) {
+                $document->stamps = json_decode($document->stamps);
+            } else {
+                $document->stamps = [];
+            }
             return response()->json([
                 'status' => 201,
                 'message' => 'OK',
@@ -112,6 +120,11 @@ class DocumentController extends Controller
                 $document->anexos = Anexo::with(['file'])->where('document_id', $document->id)->orderBy('index', 'ASC')->get();
                 $document->signatures = Signature::with(['stamp'])->where('document_id', $document->id)->get();
                 $document->body = json_decode($document->body);
+                if ($document->stamps) {
+                    $document->stamps = json_decode($document->stamps);
+                } else {
+                    $document->stamps = [];
+                }
                 return response()->json([
                     'status' => 200,
                     'message' => $loggedInUserId,
@@ -148,7 +161,7 @@ class DocumentController extends Controller
     public function update(Request $request, $id)
     {
         $data = $this->validateRequest($request, 'patch');
-        //try {
+        try {
             $document = Document::find($id);
             if (!$document || !$this->userHasAccessToDocument($request->user()->id, $document)) {
                 return response()->json([
@@ -159,21 +172,29 @@ class DocumentController extends Controller
             if (isset($data['body'] )) {
                 $data['body'] = json_encode($data['body']);
             }
+            if (isset($data['stamps'])) {
+                $data['stamps'] = json_encode( $data['stamps']);
+            }
             $document->update($data);
             $document->anexos = Anexo::with(['file'])->where('document_id', $document->id)->orderBy('index', 'ASC')->get();
             $document->signatures = Signature::with(['stamp'])->where('document_id', $document->id)->get();
             $document->body = json_decode($document->body);
+            if ($document->stamps) {
+                $document->stamps = json_decode($document->stamps);
+            } else {
+                $document->stamps = [];
+            }
             return response()->json([
                 'status' => 200,
                 'message' => 'OK',
                 'data' => $document           
             ]);
-        /*} catch (\Throwable $th) {
+        } catch (\Throwable $th) {
             return response()->json([
                 'status' => 500,
                 'message' => 'Error en el servidor. Reintente la operación'
             ], 500);
-        }*/
+        }
     }
 
     /**
@@ -223,7 +244,7 @@ class DocumentController extends Controller
     }
 
     public function search(Request $request){
-        //try {
+        try {
             $params = [
                 'keywords',
                 'document_type_id',
@@ -277,12 +298,12 @@ class DocumentController extends Controller
                 ]);
             }
             return $output; 
-        /*} catch (\Throwable $th) {
+        } catch (\Throwable $th) {
             return response()->json([
                 'status' => 500,
                 'message' => 'Error en el servidor. Reintente la operación'
             ], 500);
-        }*/
+        }
     }
 
     private function validateRequest($request , $method) {
@@ -302,6 +323,7 @@ class DocumentController extends Controller
             'visibility_level_id' => 'sometimes|numeric',
             'heading_id' => 'sometimes|numeric',
             'operative_section_beginning_id' => 'sometimes|numeric|nullable',
+            'stamps' => 'sometimes|array',
         ];
         $rules = $method == 'post' ? $requiredRules + $sometimesRules : $sometimesRules;
         $validator = Validator::make($request->all(), $rules, [
@@ -322,7 +344,7 @@ class DocumentController extends Controller
                 'heading_id' => '"Membrete"',
                 'operative_section_beginning_id' => '"Inicio de sección operativa"',
                 'true_copy_stamp_id' => '"Firmante de copia fiel"',
-                'visibility_level_id' => '"Nivel de visibilidad del documento"'
+                'visibility_level_id' => '"Nivel de visibilidad del documento"',
             ])->stopOnFirstFailure(true);
         $validator->validate();
         return $validator->validated();

--- a/api/app/Models/Document.php
+++ b/api/app/Models/Document.php
@@ -23,7 +23,8 @@ class Document extends Model
         'true_copy_stamp_id', 
         'heading_id',
         'has_anexo_unico',
-        'visibility_level_id'
+        'visibility_level_id', 
+        'stamps'
     ];
     
     public function documentCopy(){

--- a/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
+++ b/api/database/migrations/2023_10_09_171556_add_cols_to_documents_table.php
@@ -23,6 +23,7 @@ return new class extends Migration
             $table->boolean('has_anexo_unico')->default(false);
             $table->bigInteger('visibility_level_id')->nullable()->unsigned();
             $table->foreign('visibility_level_id')->references('id')->on('visibility_levels');
+            $table->text('stamps');
         });
     }
 


### PR DESCRIPTION
This pull request adds a new column to the 'documents' table, named 'stamps'. This column stores an string representing an array of HTML fragments, each one implements an stamp of the document. 

Despite the fact that is not advisable to store multiple values in a same field of a relational db, this change is made taking into account that there are no plans to perform queries on this column. 