### PR TITLE
(api) Add 'document access mode' resource

### DIFF
--- a/api/app/Http/Controllers/AccessModeController.php
+++ b/api/app/Http/Controllers/AccessModeController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\AccessMode;
+use Illuminate\Http\Request;
+
+class AccessModeController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        try { 
+            $accessModes = AccessMode::all();
+            return response()->json([
+                'status' => 200,
+                'description' => 'OK',
+                'data' => $accessModes       
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        try { 
+            $accessMode = AccessMode::find($id);
+            if(!$accessMode){
+                return response()->json([
+                    'status' => 404,
+                    'message' => 'El recurso al que desea acceder no existe'        
+                ], 404);
+            }
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $accessMode           
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+     /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/api/app/Http/Controllers/AnexoController.php
+++ b/api/app/Http/Controllers/AnexoController.php
@@ -57,6 +57,12 @@ class AnexoController extends Controller
                     'message' => 'Documento inválido'        
                 ], 422);
             }
+            if (!$this->userCanEdit($request->user()->id, $document)) {
+                return response()->json([
+                    'status' => 405,
+                    'message' => 'Recurso de solo lectura'        
+                ], 405);
+            }
             $anexo = new Anexo();
             $anexo->set($request->index, $request->title, $request->subtitle, $request->content, $document, $file);
             return response()->json([
@@ -114,9 +120,14 @@ class AnexoController extends Controller
                     'message' => 'Recurso inexistente',       
                 ], 404);  
             }
+            if (!$this->userCanEdit($request->user()->id, $anexo->document)) {
+                return response()->json([
+                    'status' => 405,
+                    'message' => 'Recurso de solo lectura'        
+                ], 405);
+            }
             $file = File::find($request->file_id);
             if (!$file || !$this->userHasAccessToDocument($file->redactaUser->id, $anexo->document)) {
-                //|| ($request->user()->id != $file->redactaUser->id) { 
                 return response()->json([
                     'status' => 422,
                     'message' => 'Archivo inválido',       
@@ -195,6 +206,23 @@ class AnexoController extends Controller
             }
         }
         return true; 
+    }
+
+    private function userCanEdit($loggedInUserId, $document) {
+        if ($document->redactaUser->id == $loggedInUserId) {
+            return true;
+        } else if (str_ends_with($document->visibilityLevel->name, 'editable')) {
+            return true;
+        } else if ($document->visibilityLevel->name == 'private') {
+            $userDocumentAccess = DocumentSharedAccess::where([
+                ['redacta_user_id', '=', $loggedInUserId],
+                ['document_id', '=', $document->id]
+            ])->get()->first();
+            if ($userDocumentAccess->accessMode->name == 'editable') {
+                return true;
+            } 
+        } 
+        return false; 
     }
 
 }

--- a/api/app/Http/Controllers/DocumentController.php
+++ b/api/app/Http/Controllers/DocumentController.php
@@ -169,6 +169,12 @@ class DocumentController extends Controller
                     'message' => 'Recurso inexistente'        
                 ], 404);
             }
+            if (!$this->userCanEdit($request->user()->id, $document)) {
+                return response()->json([
+                    'status' => 405,
+                    'message' => 'Recurso de solo lectura'        
+                ], 405);
+            }
             if (isset($data['body'] )) {
                 $data['body'] = json_encode($data['body']);
             }
@@ -401,6 +407,23 @@ class DocumentController extends Controller
             }
         }
         return true; 
+    }
+
+    private function userCanEdit($loggedInUserId, $document) {
+        if ($document->redactaUser->id == $loggedInUserId) {
+            return true;
+        } else if (str_ends_with($document->visibilityLevel->name, 'editable')) {
+            return true;
+        } else if ($document->visibilityLevel->name == 'private') {
+            $userDocumentAccess = DocumentSharedAccess::where([
+                ['redacta_user_id', '=', $loggedInUserId],
+                ['document_id', '=', $document->id]
+            ])->get()->first();
+            if ($userDocumentAccess->accessMode->name == 'editable') {
+                return true;
+            } 
+        } 
+        return false; 
     }
     
     public function exportAnexo(Request $request, $id){

--- a/api/app/Http/Controllers/DocumentSharedAccessController.php
+++ b/api/app/Http/Controllers/DocumentSharedAccessController.php
@@ -76,6 +76,9 @@ class DocumentSharedAccessController extends Controller
                     'message' => 'La cuenta seleccionada ya tiene actualmente permisos de acceso a este documento'        
                 ], 409);
             }
+            if (!isset($validatedData['access_mode_id'])) {
+                $validatedData['access_mode_id'] = 1;
+            }
             $documentSharedAccess = DocumentSharedAccess::create($validatedData);
             return response()->json([
                 'status' => 201,
@@ -178,10 +181,15 @@ class DocumentSharedAccessController extends Controller
     }
 
     private function validateRequest($request) {
+        if ($request->isMethod('post')) {
+            $firstRule = 'required';
+        } else {
+            $firstRule = 'sometimes';
+        }
         $validator = Validator::make($request->all(), [
-            'redacta_user_id' => 'required|numeric|exists:redacta_users,id',
-            'document_id' => 'required|numeric|exists:documents,id',
-            'access_mode_id' => 'required|numeric|exists:access_modes,id',
+            'redacta_user_id' => $firstRule.'|numeric|exists:redacta_users,id',
+            'document_id' => $firstRule.'|numeric|exists:documents,id',
+            'access_mode_id' => 'sometimes|numeric|exists:access_modes,id',
         ], [
             'required' => 'El campo :attribute es requerido',
             'numeric' => 'El campo :attribute debe ser numérico',

--- a/api/app/Http/Controllers/DocumentSharedAccessController.php
+++ b/api/app/Http/Controllers/DocumentSharedAccessController.php
@@ -181,12 +181,14 @@ class DocumentSharedAccessController extends Controller
         $validator = Validator::make($request->all(), [
             'redacta_user_id' => 'required|numeric|exists:redacta_users,id',
             'document_id' => 'required|numeric|exists:documents,id',
+            'access_mode_id' => 'required|numeric|exists:access_modes,id',
         ], [
             'required' => 'El campo :attribute es requerido',
             'numeric' => 'El campo :attribute debe ser numérico',
         ], [
             'redacta_user_id' => '"Usuario"',
-            'document_id' => '"Documento"'
+            'document_id' => '"Documento"',
+            'access_mode_id' => '"Modo de acceso"'
         ])->stopOnFirstFailure(true);
         $validator->validate();
         return $validator->validated();

--- a/api/app/Models/AccessMode.php
+++ b/api/app/Models/AccessMode.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AccessMode extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',   
+    ];
+}

--- a/api/app/Models/DocumentSharedAccess.php
+++ b/api/app/Models/DocumentSharedAccess.php
@@ -14,16 +14,18 @@ class DocumentSharedAccess extends Model
     protected $fillable = [
         'document_id',
         'redacta_user_id', 
+        'access_mode_id'
     ];
 
-    public function document(){
+    public function document() {
         return $this->belongsTo(Document::class);
     }
 
-    public function redactaUser(){
+    public function redactaUser() {
         return $this->belongsTo(RedactaUser::class);
     }
 
-
-
+    public function accessMode() {
+        return $this->belongsTo(AccessMode::class);
+    }
 }

--- a/api/database/migrations/2024_03_14_181334_create_documents_shared_accesses_table.php
+++ b/api/database/migrations/2024_03_14_181334_create_documents_shared_accesses_table.php
@@ -17,9 +17,11 @@ return new class extends Migration
             $table->id();
             $table->timestamps();
             $table->bigInteger('document_id')->unsigned();
-            $table->foreign('document_id')->references('id')->on('documents')->onDelete('cascade');
+            $table->foreign('document_id')->references('id')->on('documents');
             $table->bigInteger('redacta_user_id')->unsigned();
-            $table->foreign('redacta_user_id')->references('id')->on('redacta_users')->onDelete('cascade');
+            $table->foreign('redacta_user_id')->references('id')->on('redacta_users');
+            $table->bigInteger('access_mode_id')->unsigned();
+            $table->foreign('access_mode_id')->references('id')->on('access_modes');
         });
     }
 

--- a/api/database/migrations/2024_05_20_150058_create_access_modes_table.php
+++ b/api/database/migrations/2024_05_20_150058_create_access_modes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('access_modes', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->string('name');
+            $table->string('label');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('access_modes');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\SignatureController;
 use App\Http\Controllers\DocumentSharedAccessController;
 use App\Http\Controllers\RedactaUserController;
 use App\Http\Controllers\VisibilityLevelController;
+use App\Http\Controllers\AccessMode;
 
 
 /*
@@ -45,6 +46,7 @@ Route::middleware('auth:sanctum')->group(function () {
   Route::apiResource('redacta_users', RedactaUserController::class);
   Route::apiResource('visibility_levels', VisibilityLevelController::class);
   Route::patch('/documents/{id}/visibility_level', [DocumentController::class, 'setVisibilityLevel']);
+  Route::apiResource('access_modes', AccessModeController::class);
 });
 Route::get('/export_anexo/{id}', [DocumentController::class, 'exportAnexo']);
 


### PR DESCRIPTION
This pull request adds the 'document access mode' resource. This resource represents the different modes in which a user, who has been conceded access to a certain document, can interact with it. These modes are:
* editable
* read-only

Also, verifications are added to check if certain user can edit a given document
