### PR TITLE
(api) Send notifications via email when sharing a document

### DIFF
--- a/api/app/Http/Controllers/DocumentSharedAccessController.php
+++ b/api/app/Http/Controllers/DocumentSharedAccessController.php
@@ -6,6 +6,9 @@ use Illuminate\Http\Request;
 use App\Models\DocumentSharedAccess;
 use App\Models\Document;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\ShareDocumentMailService;
+
 
 
 class DocumentSharedAccessController extends Controller
@@ -78,8 +81,10 @@ class DocumentSharedAccessController extends Controller
             }
             if (!isset($validatedData['access_mode_id'])) {
                 $validatedData['access_mode_id'] = 1;
-            }
+            } 
             $documentSharedAccess = DocumentSharedAccess::create($validatedData);
+            Mail::to($documentSharedAccess->redactaUser->email)
+                ->send(new ShareDocumentMailService($document->id, $request->user()));
             return response()->json([
                 'status' => 201,
                 'message' => 'OK',
@@ -197,6 +202,38 @@ class DocumentSharedAccessController extends Controller
                 'status' => 200,
                 'message' => 'OK',
                 'data' => $documentSharedAccess           
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+
+    public function notify(Request $request, $id)
+    {
+        $validatedData = $this->validateRequest($request);
+        try {
+            $documentSharedAccess = DocumentSharedAccess::find($id);
+            if (!$documentSharedAccess) {
+                return response()->json([
+                    'status' => 404,
+                    'message' => 'Recurso inexistente'        
+                ], 404);
+            }
+            if ($documentSharedAccess->document->redactaUser->id != $request->user()->id) {
+                return response()->json([
+                    'status' => 403,
+                    'message' => 'No tiene autorización para realizar esta acción'        
+                ], 404);
+            }
+            Mail::to($documentSharedAccess->redactaUser->email)
+                ->send(new ShareDocumentMailService($documentSharedAccess->document->id, $request->user()));
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK'           
             ]);
         } catch (\Throwable $th) {
             return response()->json([

--- a/api/app/Mail/ShareDocumentMailService.php
+++ b/api/app/Mail/ShareDocumentMailService.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Models\RedactaUser;
+
+
+class ShareDocumentMailService extends Mailable
+
+{
+
+    use Queueable, SerializesModels;
+
+    /**
+
+     * Create a new message instance.
+
+     *
+
+     * @return void
+
+     */
+
+    /*public function __construct()
+
+    {
+
+        //
+
+    }*/
+
+    public function __construct(
+        protected int $documentId,
+        protected RedactaUser $sender,
+
+    ) {}
+
+    /**
+
+     * Build the message.
+
+     *
+
+     * @return $this
+
+     */
+
+    public function build()
+    {
+        return $this->view('emails.share-document')
+            ->subject('Invitación a documento')
+            ->with([
+                'url' => env('APP_URL').'/documentos/editar?id='.$this->documentId,
+                'sender' => $this->sender->name.' '.$this->sender->last_name
+            ]);
+    }
+
+}

--- a/api/resources/views/emails/share-document.blade.php
+++ b/api/resources/views/emails/share-document.blade.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body>
+        <p><b>{{$sender}}</b> te ha enviado una invitación para acceder al siguiente documento en RedActa: <a href="{{$url}}">{{$url}}</a></p>
+    </body>
+</html>

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -47,6 +47,7 @@ Route::middleware('auth:sanctum')->group(function () {
   Route::apiResource('visibility_levels', VisibilityLevelController::class);
   Route::patch('/documents/{id}/visibility_level', [DocumentController::class, 'setVisibilityLevel']);
   Route::apiResource('access_modes', AccessModeController::class);
+  Route::post('documents_shared_access/{id}/notify', [DocumentSharedAccessController::class, 'notify']);
 });
 Route::get('/export_anexo/{id}', [DocumentController::class, 'exportAnexo']);
 


### PR DESCRIPTION
This pull request adds a new feature which consists in sending a notification via email to the person who a document has been shared with. The email contains the name of the user who makes the invitation and the url to access the document.
This pull request also adds an api route for sending a notification manually.  