### PR TITLE
(api) Add  'Groups' feature 

### DIFF
--- a/api/app/Http/Controllers/AnexoController.php
+++ b/api/app/Http/Controllers/AnexoController.php
@@ -45,6 +45,7 @@ class AnexoController extends Controller
         try {
             $data = $request->validated();
             $file = File::find($data['file_id']);
+            // Check if the file exists and belongs to the user
             if (!$file || $file->redactaUser->id != $request->user()->id) {
                 return response()->json([
                     'status' => 422,
@@ -52,17 +53,12 @@ class AnexoController extends Controller
                 ], 422);
             }
             $document = Document::find($data['document_id']);
-            if (!$this->userHasAccessToDocument($request->user()->id, $document)) {
+            // Check if the document exists and can be accessed by the user
+            if (!$document->isAccessibleToRedactaUser($request->user(), 1)) {
                 return response()->json([
-                    'status' => 422,
-                    'message' => 'Documento inválido'        
+                    'status' => 403,
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
                 ], 422);
-            }
-            if (!$this->userCanEdit($request->user()->id, $document)) {
-                return response()->json([
-                    'status' => 405,
-                    'message' => 'Recurso de solo lectura'        
-                ], 405);
             }
             $anexo = new Anexo();
             $anexo->set($data['index'], $data['title'], $data['subtitle'], $data['content'], $document, $file);
@@ -78,7 +74,7 @@ class AnexoController extends Controller
                 'status' => 500,
                 'message' => 'Error en el servidor. Reintente la operación'
             ], 500);
-        } 
+        }
     }
 
     /**
@@ -115,24 +111,29 @@ class AnexoController extends Controller
         try {
             $data = $request->validated();
             $anexo = Anexo::find($id);
-            if (!$anexo || !$this->userHasAccessToDocument($request->user()->id, $anexo->document)) {
+            if (!$anexo) {
                 return response()->json([
                     'status' => 404,
                     'message' => 'Recurso inexistente',       
                 ], 404);  
             }
-            if (!$this->userCanEdit($request->user()->id, $anexo->document)) {
+            // Check if the user has access to the document
+            if (!$anexo->document->isAccessibleToRedactaUser($request->user(), 1)) {
                 return response()->json([
-                    'status' => 405,
-                    'message' => 'Recurso de solo lectura'        
-                ], 405);
+                    'status' => 403,
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                ], 403);
             }
-            $file = File::find($data['file_id']);
-            if (!$file || !$this->userHasAccessToDocument($file->redactaUser->id, $anexo->document)) {
-                return response()->json([
-                    'status' => 422,
-                    'message' => 'Archivo inválido',       
-                ], 422);  
+
+            if (isset($data['file_id'])) {
+                // Check if the file exists and belongs to the user
+                $file = File::find($data['file_id']);
+                if ($file->redactaUser->id != $request->user()->id) {
+                    return response()->json([
+                        'status' => 422,
+                        'message' => 'Archivo inválido'        
+                    ], 422);
+                }
             }
             $anexo->set($data['index'], $data['title'], $data['subtitle'], $data['content'], $anexo->document, $file);
             return response()->json([
@@ -160,12 +161,19 @@ class AnexoController extends Controller
     {
         try {
             $anexo =  Anexo::find($id);
-            if(!$anexo || !$this->userHasAccessToDocument($request->user()->id, $anexo->document)){
+            if(!$anexo){
                 return response()->json([
                     'status' => 404,
                     'message' => 'Recurso inexistente',       
                 ], 404);     
             } 
+            // Check if the user has access to the document
+            if (!$anexo->document->isAccessibleToRedactaUser($request->user(), 1)) {
+                return response()->json([
+                    'status' => 403,
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                ], 403);            
+            }
             $anexo->delete();
             return response()->json([
                 'status' => 200,
@@ -181,35 +189,4 @@ class AnexoController extends Controller
             ], 500);
         } 
     }
-
-    private function userHasAccessToDocument($loggedInUserId, $document) {
-        if ($document->redactaUser->id != $loggedInUserId && $document->visibilityLevel->name == 'private') {
-            $documentSharedAccess = DocumentSharedAccess::where([
-                ['redacta_user_id', '=', $loggedInUserId],
-                ['document_id', '=', $document->id]
-            ])->get();
-            if (count($documentSharedAccess) == 0) {
-                return false;
-            }
-        }
-        return true; 
-    }
-
-    private function userCanEdit($loggedInUserId, $document) {
-        if ($document->redactaUser->id == $loggedInUserId) {
-            return true;
-        } else if (str_ends_with($document->visibilityLevel->name, 'editable')) {
-            return true;
-        } else if ($document->visibilityLevel->name == 'private') {
-            $userDocumentAccess = DocumentSharedAccess::where([
-                ['redacta_user_id', '=', $loggedInUserId],
-                ['document_id', '=', $document->id]
-            ])->get()->first();
-            if ($userDocumentAccess->accessMode->name == 'editable') {
-                return true;
-            } 
-        } 
-        return false; 
-    }
-
 }

--- a/api/app/Http/Controllers/DocumentController.php
+++ b/api/app/Http/Controllers/DocumentController.php
@@ -100,11 +100,11 @@ class DocumentController extends Controller
         try {
             $document = Document::find($id);
             $loggedInUserId = $request->user()->id;
-            if (!$document || !$this->userHasAccessToDocument($loggedInUserId, $document)) {
+            if (!$document->isAccessibleToRedactaUser($request->user(), 2)) {
                 return response()->json([
-                    'status' => 404,
-                    'message' => 'Recurso inexistente'        
-                ], 404);
+                    'status' => 403,
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                ], 403);
             }                  
             if ($request->accepts(['application/pdf'])) {                
                 $isCopy = $request->boolean('is_copy', false);
@@ -119,6 +119,7 @@ class DocumentController extends Controller
                     ->header('Content-Disposition', 'attachment; filename="'.$filename.'.pdf"; filename*="'.$filename.'.pdf"')
                     ->header('Access-Control-Expose-Headers', 'Content-Disposition');
             } else if ($request->accepts(['application/json'])) {
+                $document->load('documentSharedAccesses');
                 $document->anexos = Anexo::with(['file'])->where('document_id', $document->id)->orderBy('index', 'ASC')->get();
                 $document->signatures = Signature::with(['stamp'])->where('document_id', $document->id)->get();
                 $document->body = json_decode($document->body);
@@ -165,18 +166,13 @@ class DocumentController extends Controller
         try {
             $data = $request->validated();
             $document = Document::find($id);
-            if (!$document || !$this->userHasAccessToDocument($request->user()->id, $document)) {
+            if (!$document->isAccessibleToRedactaUser($request->user(), 1)) {
                 return response()->json([
-                    'status' => 404,
-                    'message' => 'Recurso inexistente'        
-                ], 404);
+                    'status' => 403,
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                ], 403);
             }
-            if (!$this->userCanEdit($request->user()->id, $document)) {
-                return response()->json([
-                    'status' => 405,
-                    'message' => 'Recurso de solo lectura'        
-                ], 405);
-            }
+
             if (isset($data['body'] )) {
                 $data['body'] = json_encode($data['body']);
             }
@@ -222,11 +218,12 @@ class DocumentController extends Controller
     {
         try { 
             $document = Document::find($id);
-            if (!$document || $document->redactaUser->id != $request->user()->id) {
+            //if (!$document || $document->redactaUser->id != $request->user()->id) {
+            if (!$document->isAccessibleToRedactaUser($request->user(), 1)) {
                 return response()->json([
-                    'status' => 404,
-                    'message' => 'Recurso inexistente'        
-                ], 404);
+                    'status' => 403,
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                ], 403);
             }
             $document->delete();
             return response()->json([
@@ -315,10 +312,24 @@ class DocumentController extends Controller
             $isCopy = $request->boolean('is_copy', false);
             $query =  Document::with(['issuer','documentType']);
             if ($request->boolean('shared', false)) {
-                $documentsId = DocumentSharedAccess::where('redacta_user_id', $request->user()->id)->pluck('document_id')->all();
-                $documentsId = array_merge($documentsId, Document::whereIn('visibility_level_id', [2, 3])->where('redacta_user_id','<>',$request->user()->id)
-                            ->pluck('id')->all());
-                $query = Document::whereIn('id', $documentsId);
+                // Get ids from documents shared with the currrent user
+                $sharedDocumentIds = DocumentSharedAccess::where('document_shared_accessable_type', 'App\\Models\\RedactaUser')
+                    ->where('document_shared_accessable_id', $request->user()->id)
+                    ->pluck('document_id')
+                    ->toArray();
+
+                // Get ids from documents shared with groups which current user belongs to
+                $userGroupIds = $request->user()->groups()->pluck('group_id')->toArray();
+                $groupSharedDocumentIds = DocumentSharedAccess::where('document_shared_accessable_type', 'App\\Models\\Group')
+                    ->whereIn('document_shared_accessable_id', $userGroupIds)
+                    ->pluck('document_id')
+                    ->toArray();
+
+                // Merge both arrays and remove duplicates
+                $documentsId = array_unique(array_merge($sharedDocumentIds, $groupSharedDocumentIds));
+
+                $query = Document::whereIn('id', $documentsId)
+                    ->where('redacta_user_id', '<>', $request->user()->id);
             } else {
                 $query = Document::where('redacta_user_id', $request->user()->id);
             }
@@ -349,7 +360,7 @@ class DocumentController extends Controller
                     'name' => $document->name,
                     'issueDate' => $document->issue_date ? date('d-m-Y', strtotime($document->issue_date)) : '',
                     'number' => $document->number,
-                    'updated_at' => date('d-m-Y H:m:s', strtotime($document->updated_at))
+                    'updated_at' => date('d-m-Y H:m:s', strtotime($document->updated_at)),
                 ]);
             }
             return $output; 
@@ -359,36 +370,6 @@ class DocumentController extends Controller
                 'message' => 'Error en el servidor. Reintente la operación'
             ], 500);
         }
-    }
-
-    private function userHasAccessToDocument($loggedInUserId, $document) {
-        if ($document->redactaUser->id != $loggedInUserId && $document->visibilityLevel->name == 'private') {
-            $documentSharedAccess = DocumentSharedAccess::where([
-                ['redacta_user_id', '=', $loggedInUserId],
-                ['document_id', '=', $document->id]
-            ])->get();
-            if (count($documentSharedAccess) == 0) {
-                return false;
-            }
-        }
-        return true; 
-    }
-
-    private function userCanEdit($loggedInUserId, $document) {
-        if ($document->redactaUser->id == $loggedInUserId) {
-            return true;
-        } else if (str_ends_with($document->visibilityLevel->name, 'editable')) {
-            return true;
-        } else if ($document->visibilityLevel->name == 'private') {
-            $userDocumentAccess = DocumentSharedAccess::where([
-                ['redacta_user_id', '=', $loggedInUserId],
-                ['document_id', '=', $document->id]
-            ])->get()->first();
-            if ($userDocumentAccess->accessMode->name == 'editable') {
-                return true;
-            } 
-        } 
-        return false; 
     }
     
     public function exportAnexo(Request $request, $id){

--- a/api/app/Http/Controllers/DocumentSharedAccessController.php
+++ b/api/app/Http/Controllers/DocumentSharedAccessController.php
@@ -24,11 +24,12 @@ class DocumentSharedAccessController extends Controller
     {
         try {       
             if ($request->has('document_id')) {
-                if (!$this->userHasAccessToDocument($request->user()->id, Document::find($request->query('document_id')))) {
+                $document = Document::find($request->query('document_id'));
+                if (!$document->isAccessibleToRedactaUser($request->user(), 2)) {
                     return response()->json([
-                        'status' => 422,
-                        'message' => 'Documento inválido'        
-                    ], 422);
+                        'status' => 403,
+                        'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                    ], 403);
                 }
                 $result = DocumentSharedAccess::where('document_id', $request->query('document_id'))->get();
             } else {
@@ -68,28 +69,55 @@ class DocumentSharedAccessController extends Controller
         try {
             $validatedData = $request->validated();
             $document = Document::find($validatedData['document_id']);
-            if ($document->redactaUser->id != $request->user()->id) {
+            if (!$document) {
                 return response()->json([
-                    'status' => 422,
-                    'message' => 'Documento inválido'        
-                ], 422);
+                    'status' => 404,
+                    'message' => 'Recurso inexistente'
+                ], 404);
             }
-            if ($this->userHasAccessToDocument($validatedData['redacta_user_id'], $document)) {
+            if (!$document->isAccessibleToRedactaUser($request->user(), 1)) {
+                return response()->json([
+                    'status' => 403,
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                ], 403);
+            }
+
+            $validatedData = $this->setDocumentSharedAccessableFields($validatedData, $request);
+
+            // Check if exists a document shared access for the same user/group
+            if ($document->documentSharedAccesses()
+                    ->where('document_shared_accessable_type', $validatedData['document_shared_accessable_type'])
+                    ->where('document_shared_accessable_id', $validatedData['document_shared_accessable_id'])
+                    ->exists()) {
                 return response()->json([
                     'status' => 409,
-                    'message' => 'La cuenta seleccionada ya tiene actualmente permisos de acceso a este documento'        
+                    'message' => 'Ya existe un acceso compartido al documento para el usuario o grupo seleccionado'        
                 ], 409);
             }
-            if (!isset($validatedData['access_mode_id'])) {
-                $validatedData['access_mode_id'] = 1;
-            } 
+            
             $documentSharedAccess = DocumentSharedAccess::create($validatedData);
-            Mail::to($documentSharedAccess->redactaUser->email)
-                ->send(new ShareDocumentMailService($document->id, $request->user()));
+
+            // Notify the user or group members about the shared access
+            $usersToNotify = [];
+            if ($validatedData['document_shared_accessable_type'] == 'App\Models\RedactaUser') {
+                $usersToNotify[] = $documentSharedAccess->document_shared_accessable;
+            } else {
+                foreach ($documentSharedAccess->documentSharedAccessable->redactaUsers as $user) {
+                    $usersToNotify[] = $user;
+                }
+            }
+
+            foreach ($usersToNotify as $user) {
+                if ($user->id != $request->user()->id) {
+                    Mail::to($user->email)
+                        ->send(new ShareDocumentMailService($document->id, $request->user()));
+                }
+            }
+
             return response()->json([
                 'status' => 201,
                 'message' => 'OK',
-                'data' => $documentSharedAccess           
+                'data' => $documentSharedAccess
             ]);
         } catch (\Throwable $th) {
             return response()->json([
@@ -110,12 +138,11 @@ class DocumentSharedAccessController extends Controller
     {
         try {
             $documentSharedAccess = DocumentSharedAccess::find($id);
-            if (!$documentSharedAccess || 
-                !$this->userHasAccessToDocument($request->user()->id, $documentSharedAccess->document)) {
+            if (!$documentSharedAccess->document->isAccessibleToRedactaUser($request->user(), 2)) {
                 return response()->json([
-                    'status' => 404,
-                    'message' => 'Recurso inexistente'        
-                ], 404);
+                    'status' => 403,
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                ], 403);
             }
             return response()->json([
                 'status' => 200,
@@ -153,18 +180,54 @@ class DocumentSharedAccessController extends Controller
         try {
             $validatedData = $request->validated();
             $documentSharedAccess = DocumentSharedAccess::find($id);
+
             if (!$documentSharedAccess) {
                 return response()->json([
                     'status' => 404,
-                    'message' => 'Recurso inexistente'        
+                    'message' => 'Recurso inexistente'
                 ], 404);
             }
-            if ($documentSharedAccess->document->redactaUser->id != $request->user()->id) {
+
+            $documentSharedAccessableIdHasChanged = false;
+            $documentSharedAccessableTypeHasChanged = false;
+            $documentSharedAccessableId = $documentSharedAccess->document_shared_accessable_id;
+            $documentSharedAccessableType = $documentSharedAccess->document_shared_accessable_type;
+
+            if (!$documentSharedAccess->document || !$documentSharedAccess->document->isAccessibleToRedactaUser($request->user(), 1)) {
                 return response()->json([
                     'status' => 403,
-                    'message' => 'No tiene autorización para realizar esta acción'        
-                ], 404);
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                ], 403);
             }
+
+            $validatedData = $this->setDocumentSharedAccessableFields($validatedData, $request);
+
+            if (isset($validatedData['document_shared_accessable_id'])) {
+                $documentSharedAccessableIdHasChanged = $validatedData['document_shared_accessable_id'] != $documentSharedAccess->document_shared_accessable_id;
+                $documentSharedAccessableId = $validatedData['document_shared_accessable_id'];
+            }
+
+            if (isset($validatedData['document_shared_accessable_type'])) {
+                $documentSharedAccessableTypeHasChanged = $validatedData['document_shared_accessable_type'] != $documentSharedAccess->document_shared_accessable_type;
+                $documentSharedAccessableType = $validatedData['document_shared_accessable_type'];
+            }
+
+            // Check if the resource has changed
+            if ($documentSharedAccessableIdHasChanged || $documentSharedAccessableTypeHasChanged) {
+                $documentSharedAccessableType = $validatedData['document_shared_accessable_type'] ?? $documentSharedAccess->document_shared_accessable_type;
+                $documentSharedAccessableId = $validatedData['document_shared_accessable_id'] ?? $documentSharedAccess->document_shared_accessable_id;
+                // Check if exists a document shared access for the same user/group
+                if ($documentSharedAccess->document->documentSharedAccesses()
+                        ->where('document_shared_accessable_type', $documentSharedAccessableType)
+                        ->where('document_shared_accessable_id', $documentSharedAccessableId)
+                        ->exists()) {
+                    return response()->json([
+                        'status' => 409,
+                        'message' => 'Ya existe un acceso compartido al documento para el usuario o grupo seleccionado'        
+                    ], 409);
+                }
+            }
+
             $documentSharedAccess->update($validatedData);
             return response()->json([
                 'status' => 200,
@@ -190,13 +253,17 @@ class DocumentSharedAccessController extends Controller
     {
         try { 
             $documentSharedAccess = DocumentSharedAccess::find($id);
-            if (!$documentSharedAccess || 
-                ($documentSharedAccess->redactaUser->id != $request->user()->id &&
-                    $documentSharedAccess->document->redactaUser->id != $request->user()->id)) {
+            if (!$documentSharedAccess) {
                 return response()->json([
                     'status' => 404,
-                    'message' => 'Recurso inexistente'        
+                    'message' => 'Recurso inexistente'
                 ], 404);
+            }
+            if (!$documentSharedAccess->document->isAccessibleToRedactaUser($request->user(), 1)) {
+                return response()->json([
+                    'status' => 403,
+                    'message' => 'No tiene los permisos necesarios para realizar la operación'        
+                ], 403);
             }
             $documentSharedAccess->delete();
             return response()->json([
@@ -228,7 +295,7 @@ class DocumentSharedAccessController extends Controller
                 return response()->json([
                     'status' => 403,
                     'message' => 'No tiene autorización para realizar esta acción'        
-                ], 404);
+                ], 403);
             }
             Mail::to($documentSharedAccess->redactaUser->email)
                 ->send(new ShareDocumentMailService($documentSharedAccess->document->id, $request->user()));
@@ -244,16 +311,26 @@ class DocumentSharedAccessController extends Controller
         }
     }
 
-    private function userHasAccessToDocument($loggedInUserId, $document) {
-        if ($document->redactaUser->id != $loggedInUserId) {
-            $documentSharedAccess = DocumentSharedAccess::where([
-                ['redacta_user_id', '=', $loggedInUserId],
-                ['document_id', '=', $document->id]
-            ])->get();
-            if (count($documentSharedAccess) == 0) {
-                return false;
-            }
+    /**
+     * Set document_shared_accessable_id and document_shared_accessable_type fields.
+     *
+     * @param array $validatedData
+     * @param \Illuminate\Http\Request $request
+     * @return array
+     */
+    private function setDocumentSharedAccessableFields(array $validatedData, Request $request)
+    {
+        if ($request->isMethod('post') && !isset($validatedData['access_mode_id'])){
+                $validatedData['access_mode_id'] = 1;
         }
-        return true; 
+        if (isset($validatedData['resource_id'])) {
+            $validatedData['document_shared_accessable_id'] = $validatedData['resource_id'];
+        }
+        if ($request->has('resource_type')) {
+            $validatedData['document_shared_accessable_type'] = $request->input('resource_type') == 'group'
+                ? 'App\Models\Group'
+                : 'App\Models\RedactaUser';
+        }
+        return $validatedData;
     }
 }

--- a/api/app/Http/Controllers/GroupController.php
+++ b/api/app/Http/Controllers/GroupController.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreGroupRequest;
+use App\Http\Requests\UpdateGroupRequest;
+use App\Models\Group;
+
+class GroupController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        try {
+            $groups = auth()->user()->groups->load('redactaUsers');
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $groups
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \App\Http\Requests\StoreGroupRequest  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StoreGroupRequest $request)
+    {
+        try {
+            $data = $request->validated();
+            $group = Group::create($data);
+            return response()->json([
+                'status' => 201,
+                'message' => 'OK',
+                'data' => $group
+            ], 201);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\Group  $group
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Group $group)
+    {
+        try {
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $group
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+        
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\Group  $group
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(Group $group)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \App\Http\Requests\UpdateGroupRequest  $request
+     * @param  \App\Models\Group  $group
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UpdateGroupRequest $request, Group $group)
+    {
+        try {
+            $data = $request->validated();
+            $group->update($data);
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $group
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\Group  $group
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Group $group)
+    {
+        try {
+            $group->delete();
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK'
+            ], 200);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+}

--- a/api/app/Http/Controllers/GroupMembershipController.php
+++ b/api/app/Http/Controllers/GroupMembershipController.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreGroupMembershipRequest;
+use App\Http\Requests\UpdateGroupMembershipRequest;
+use App\Models\GroupMembership;
+use App\Models\Group;
+use App\Models\RedactaUser;
+
+class GroupMembershipController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $groupMemberships = auth()->user()->groupMemberships()->with(['group', 'redactaUser'])->get();
+        return response()->json([
+            'status' => 200,
+            'message' => 'OK',
+            'data' => $groupMemberships
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \App\Http\Requests\StoreGroupMembershipRequest  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StoreGroupMembershipRequest $request)
+    {
+        try {
+            $data = $request->validated();
+            $group = Group::find($data['group_id']);
+            $redactaUser = RedactaUser::find($data['redacta_user_id']);
+            if ($group->redactaUsers->contains($redactaUser)) {
+                return response()->json([
+                    'status' => 422,
+                    'message' => 'El usuario ya es miembro del grupo'
+                ], 422);
+            }
+            $groupMembership = GroupMembership::create($data);
+            return response()->json([
+                'status' => 201,
+                'message' => 'OK',
+                'data' => $groupMembership
+            ], 201);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\GroupMembership  $groupMembership
+     * @return \Illuminate\Http\Response
+     */
+    public function show(GroupMembership $groupMembership)
+    {
+        return response()->json([
+            'status' => 200,
+            'message' => 'OK',
+            'data' => $groupMembership
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\GroupMembership  $groupMembership
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(GroupMembership $groupMembership)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \App\Http\Requests\UpdateGroupMembershipRequest  $request
+     * @param  \App\Models\GroupMembership  $groupMembership
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UpdateGroupMembershipRequest $request, GroupMembership $groupMembership)
+    {
+        try {
+            $data = $request->validated();
+            $group = Group::find($data['group_id']);
+            $redactaUser = RedactaUser::find($data['redacta_user_id']);
+            if ($group->redactaUsers->contains($redactaUser)) {
+                return response()->json([
+                    'status' => 422,
+                    'message' => 'El usuario ya es miembro del grupo'
+                ], 422);
+            }
+            $groupMembership->update($data);
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK',
+                'data' => $groupMembership
+            ]);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\GroupMembership  $groupMembership
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(GroupMembership $groupMembership)
+    {
+        try {
+            $groupMembership->delete();
+            return response()->json([
+                'status' => 200,
+                'message' => 'OK'
+            ], 200);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'status' => 500,
+                'message' => 'Error en el servidor. Reintente la operación'
+            ], 500);
+        }
+    }
+}

--- a/api/app/Http/Requests/StoreDocumentSharedAccessRequest.php
+++ b/api/app/Http/Requests/StoreDocumentSharedAccessRequest.php
@@ -25,10 +25,15 @@ class StoreDocumentSharedAccessRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            'redacta_user_id' => 'required|numeric|exists:redacta_users,id',
+        $rules = [
             'document_id' => 'required|numeric|exists:documents,id',
             'access_mode_id' => 'sometimes|numeric|exists:access_modes,id'
         ];
+        if ($this->input('resource_type') === 'group') {
+            $rules['resource_id'] = 'required|numeric|exists:groups,id';
+        } else {
+            $rules['resource_id'] = 'required|numeric|exists:redacta_users,id';
+        }
+        return $rules;
     }
 }

--- a/api/app/Http/Requests/StoreGroupMembershipRequest.php
+++ b/api/app/Http/Requests/StoreGroupMembershipRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreGroupMembershipRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'group_id' => 'required|integer|exists:groups,id',
+            'redacta_user_id' => 'required|integer|exists:redacta_users,id',
+        ];
+    }
+}

--- a/api/app/Http/Requests/StoreGroupRequest.php
+++ b/api/app/Http/Requests/StoreGroupRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreGroupRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|string|max:255|unique:groups,name',
+        ];
+    }
+}

--- a/api/app/Http/Requests/UpdateDocumentSharedAccessRequest.php
+++ b/api/app/Http/Requests/UpdateDocumentSharedAccessRequest.php
@@ -26,10 +26,15 @@ class UpdateDocumentSharedAccessRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            'redacta_user_id' => 'sometimes|numeric|exists:redacta_users,id',
+        $rules = [
             'document_id' => 'sometimes|numeric|exists:documents,id',
             'access_mode_id' => 'sometimes|numeric|exists:access_modes,id'
         ];
+        if ($this->input('resource_type') === 'group') {
+            $rules['resource_id'] = 'sometimes|numeric|exists:groups,id';
+        } else {
+            $rules['resource_id'] = 'sometimes|numeric|exists:redacta_users,id';
+        }
+        return $rules;
     }
 }

--- a/api/app/Http/Requests/UpdateGroupMembershipRequest.php
+++ b/api/app/Http/Requests/UpdateGroupMembershipRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateGroupMembershipRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'group_id' => 'required|integer|exists:groups,id',
+            'user_id' => 'required|integer|exists:redacta_users,id',        
+        ];
+    }
+}

--- a/api/app/Http/Requests/UpdateGroupRequest.php
+++ b/api/app/Http/Requests/UpdateGroupRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateGroupRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|string|max:255|unique:groups,name',
+        ];
+    }
+}

--- a/api/app/Models/Document.php
+++ b/api/app/Models/Document.php
@@ -106,25 +106,32 @@ class Document extends Model
         }
 
         // Check if the user has shared access to the document
-        $sharedAccess = $this->documentSharedAccesses()
-            ->where('redacta_user_id', $redactaUser->id)
-            ->where('access_mode_id', '<=', $accessModeId)
-            ->first();
+        $sharedAccess = null;
+        if ($redactaUser) {
+            $sharedAccess = $this->documentSharedAccesses()
+                ->where('document_shared_accessable_type', 'App\Models\RedactaUser')
+                ->where('document_shared_accessable_id', $redactaUser->id)
+                ->where('access_mode_id', '<=', $accessModeId)
+                ->first();
+        }
 
         if ($sharedAccess) {
             return true;
         }
 
         // If shared access does not exist, check if the user is part of a group that has access
-        $sharedAccess = $this->documentSharedAccesses()
-            ->whereHas('documentSharedAccessable', function ($query) use ($redactaUser) {
-                $query->whereHas('redactaUsers', function ($query) use ($redactaUser) {
-                    $query->where('redacta_user_id', $redactaUser->id);
+        $sharedAccess = $this->documentSharedAccesses()->whereHasMorph(
+            'documentSharedAccessable',
+            [\App\Models\Group::class],
+            function ($query) use ($redactaUser) {
+                $query->whereHas('redactaUsers', function ($q) use ($redactaUser) {
+                    $q->where('redacta_users.id', $redactaUser->id);
                 });
             })
             ->where('access_mode_id', '<=', $accessModeId)
             ->first();
-        
+
+            
         if ($sharedAccess) {
             return true;
         }

--- a/api/app/Models/Document.php
+++ b/api/app/Models/Document.php
@@ -97,4 +97,38 @@ class Document extends Model
             }
         }
     }
+
+    public function isAccessibleToRedactaUser(RedactaUser $redactaUser, int $accessModeId)
+    {
+        // Check if the document is owned by the user
+        if ($redactaUser && $this->redactaUser->id === $redactaUser->id) {
+            return true;
+        }
+
+        // Check if the user has shared access to the document
+        $sharedAccess = $this->documentSharedAccesses()
+            ->where('redacta_user_id', $redactaUser->id)
+            ->where('access_mode_id', '<=', $accessModeId)
+            ->first();
+
+        if ($sharedAccess) {
+            return true;
+        }
+
+        // If shared access does not exist, check if the user is part of a group that has access
+        $sharedAccess = $this->documentSharedAccesses()
+            ->whereHas('documentSharedAccessable', function ($query) use ($redactaUser) {
+                $query->whereHas('redactaUsers', function ($query) use ($redactaUser) {
+                    $query->where('redacta_user_id', $redactaUser->id);
+                });
+            })
+            ->where('access_mode_id', '<=', $accessModeId)
+            ->first();
+        
+        if ($sharedAccess) {
+            return true;
+        }
+    
+        return false;
+    }
 }

--- a/api/app/Models/DocumentSharedAccess.php
+++ b/api/app/Models/DocumentSharedAccess.php
@@ -9,23 +9,40 @@ class DocumentSharedAccess extends Model
 {
     use HasFactory;
     protected $table = 'documents_shared_accesses';
-    protected $with = ['redactaUser'];
 
     protected $fillable = [
         'document_id',
-        'redacta_user_id', 
-        'access_mode_id'
+        'access_mode_id',
+        'document_shared_accessable_type',
+        'document_shared_accessable_id',
     ];
+
+    protected $hidden = ['document_shared_accessable_type', 'document_shared_accessable_id'];
+
+    protected $maps = [
+        'document_shared_accessable_type' => 'resource_type',
+        'document_shared_accessable_id' => 'resource_id',
+    ];
+
+    protected $appends = ['resource_type', 'resource_id'];
 
     public function document() {
         return $this->belongsTo(Document::class);
     }
 
-    public function redactaUser() {
-        return $this->belongsTo(RedactaUser::class);
-    }
-
     public function accessMode() {
         return $this->belongsTo(AccessMode::class);
+    }
+
+    public function documentSharedAccessable() {
+        return $this->morphTo();
+    }
+
+    public function getResourceTypeAttribute() {
+            return $this->attributes['document_shared_accessable_type'] == 'App\Models\Group' ? 'group' : 'redactaUser';
+    }
+
+    public function getResourceIdAttribute() {
+        return $this->attributes['document_shared_accessable_id'];
     }
 }

--- a/api/app/Models/Group.php
+++ b/api/app/Models/Group.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Group extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+    protected $hidden = [
+        'pivot',
+    ];
+
+    public function redactaUsers()
+    {
+        return $this->belongsToMany(RedactaUser::class, 'group_memberships', 'group_id', 'redacta_user_id');
+    }
+
+    public function documentSharedAccesses()
+    {
+        return $this->morphMany(DocumentSharedAccess::class, 'document_shared_accessable');
+    }
+}

--- a/api/app/Models/GroupMembership.php
+++ b/api/app/Models/GroupMembership.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class GroupMembership extends Model
+{
+    use HasFactory;
+    protected $fillable = [
+        'redacta_user_id',
+        'group_id',
+    ];
+
+    public function redactaUser()
+    {
+        return $this->belongsTo(RedactaUser::class, 'redacta_user_id');
+    }
+
+    public function group()
+    {
+        return $this->belongsTo(Group::class, 'group_id');
+    }
+}

--- a/api/app/Models/RedactaUser.php
+++ b/api/app/Models/RedactaUser.php
@@ -24,6 +24,7 @@ class RedactaUser extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'pivot'
     ];
 
 //hasMany
@@ -52,9 +53,19 @@ class RedactaUser extends Authenticatable
         return $this->hasMany(Stamp::class);
     }
 
-    public function documentsSharedAccesses()
+    public function groups()
     {
-        return $this->hasMany(DocumentSharedAccess::class);
+        return $this->belongsToMany(Group::class, 'group_memberships', 'redacta_user_id', 'group_id');
+    }
+
+    public function groupMemberships()
+    {
+        return $this->hasMany(GroupMembership::class, 'redacta_user_id');
+    }
+
+    public function documentSharedAccesses()
+    {
+        return $this->morphMany(DocumentSharedAccess::class, 'document_shared_accessable');
     }
 
 }

--- a/api/database/migrations/2025_06_19_135358_create_groups_table.php
+++ b/api/database/migrations/2025_06_19_135358_create_groups_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('groups');
+    }
+};

--- a/api/database/migrations/2025_06_19_142311_create_group_memberships_table.php
+++ b/api/database/migrations/2025_06_19_142311_create_group_memberships_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('group_memberships', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->foreignId('redacta_user_id')->constrained('redacta_users')->onDelete('cascade');
+            $table->foreignId('group_id')->constrained('groups')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('group_memberships');
+    }
+};

--- a/api/database/migrations/2025_06_19_153254_alter_documents_shared_accesses_table.php
+++ b/api/database/migrations/2025_06_19_153254_alter_documents_shared_accesses_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('documents_shared_accesses', function (Blueprint $table) {
+            $table->renameColumn('redacta_user_id', 'document_shared_accessable_id');
+            $table->dropForeign(['redacta_user_id']);
+            $table->string('document_shared_accessable_type')->default('App\\Models\\RedactaUser');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $table->renameColumn('document_shared_accessable_id', 'redacta_user_id');
+        $table->foreign('redacta_user_id')->references('id')->on('redacta_users');
+        $table->dropColumn('document_shared_accessable_type');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -18,6 +18,8 @@ use App\Http\Controllers\RedactaUserController;
 use App\Http\Controllers\VisibilityLevelController;
 use App\Http\Controllers\AccessModeController;
 use App\Http\Controllers\GroupController;
+use App\Http\Controllers\GroupMembershipController;
+
 
 /*
 |--------------------------------------------------------------------------
@@ -49,6 +51,7 @@ Route::middleware('auth:sanctum')->group(function () {
   Route::apiResource('access_modes', AccessModeController::class);
   Route::post('documents_shared_access/{id}/notify', [DocumentSharedAccessController::class, 'notify']);
   Route::apiResource('groups', GroupController::class);
+  Route::apiResource('group_memberships', GroupMembershipController::class);
 });
 Route::get('/export_anexo/{id}', [DocumentController::class, 'exportAnexo']);
 Route::post('/register', [AuthenticationController::class, 'register']);

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -17,7 +17,7 @@ use App\Http\Controllers\DocumentSharedAccessController;
 use App\Http\Controllers\RedactaUserController;
 use App\Http\Controllers\VisibilityLevelController;
 use App\Http\Controllers\AccessModeController;
-
+use App\Http\Controllers\GroupController;
 
 /*
 |--------------------------------------------------------------------------
@@ -48,11 +48,9 @@ Route::middleware('auth:sanctum')->group(function () {
   Route::patch('/documents/{id}/visibility_level', [DocumentController::class, 'setVisibilityLevel']);
   Route::apiResource('access_modes', AccessModeController::class);
   Route::post('documents_shared_access/{id}/notify', [DocumentSharedAccessController::class, 'notify']);
+  Route::apiResource('groups', GroupController::class);
 });
 Route::get('/export_anexo/{id}', [DocumentController::class, 'exportAnexo']);
-
-
-
 Route::post('/register', [AuthenticationController::class, 'register']);
 Route::post('/login', [AuthenticationController::class, 'login']);
 


### PR DESCRIPTION
This pull request adds "groups of users" feature to the api, allowing to set groups between registered users of the system. Then, for example, a given document can be shared with a group and each of its members can access it (which is more convenient than sharing the document user by user).

This PR:
* adds 'Groups' and 'GroupMemberships' resources
* makes changes in 'documents_shared_access' table, considering that from now, a document can be shared not only to a single user, but also with groups. 
* update those verifications that check if a given user can perform certain action on a document, considering that from now the user can access it also if the document has been shared with a group which that user belongs to
