### PR TITLE
(api) Allow to only modify 'access mode' when updating a document shared access - Store id of the user who shared a document access

### DIFF
--- a/api/app/Http/Controllers/DocumentSharedAccessController.php
+++ b/api/app/Http/Controllers/DocumentSharedAccessController.php
@@ -95,6 +95,7 @@ class DocumentSharedAccessController extends Controller
                 ], 409);
             }
             
+            $validatedData['shared_by'] = $request->user()->id;
             $documentSharedAccess = DocumentSharedAccess::create($validatedData);
 
             // Notify the user or group members about the shared access

--- a/api/app/Http/Controllers/DocumentSharedAccessController.php
+++ b/api/app/Http/Controllers/DocumentSharedAccessController.php
@@ -188,44 +188,11 @@ class DocumentSharedAccessController extends Controller
                 ], 404);
             }
 
-            $documentSharedAccessableIdHasChanged = false;
-            $documentSharedAccessableTypeHasChanged = false;
-            $documentSharedAccessableId = $documentSharedAccess->document_shared_accessable_id;
-            $documentSharedAccessableType = $documentSharedAccess->document_shared_accessable_type;
-
-            if (!$documentSharedAccess->document || !$documentSharedAccess->document->isAccessibleToRedactaUser($request->user(), 1)) {
+            if (!$documentSharedAccess->document->isAccessibleToRedactaUser($request->user(), 1)) {
                 return response()->json([
                     'status' => 403,
                     'message' => 'No tiene los permisos necesarios para realizar la operación'        
                 ], 403);
-            }
-
-            $validatedData = $this->setDocumentSharedAccessableFields($validatedData, $request);
-
-            if (isset($validatedData['document_shared_accessable_id'])) {
-                $documentSharedAccessableIdHasChanged = $validatedData['document_shared_accessable_id'] != $documentSharedAccess->document_shared_accessable_id;
-                $documentSharedAccessableId = $validatedData['document_shared_accessable_id'];
-            }
-
-            if (isset($validatedData['document_shared_accessable_type'])) {
-                $documentSharedAccessableTypeHasChanged = $validatedData['document_shared_accessable_type'] != $documentSharedAccess->document_shared_accessable_type;
-                $documentSharedAccessableType = $validatedData['document_shared_accessable_type'];
-            }
-
-            // Check if the resource has changed
-            if ($documentSharedAccessableIdHasChanged || $documentSharedAccessableTypeHasChanged) {
-                $documentSharedAccessableType = $validatedData['document_shared_accessable_type'] ?? $documentSharedAccess->document_shared_accessable_type;
-                $documentSharedAccessableId = $validatedData['document_shared_accessable_id'] ?? $documentSharedAccess->document_shared_accessable_id;
-                // Check if exists a document shared access for the same user/group
-                if ($documentSharedAccess->document->documentSharedAccesses()
-                        ->where('document_shared_accessable_type', $documentSharedAccessableType)
-                        ->where('document_shared_accessable_id', $documentSharedAccessableId)
-                        ->exists()) {
-                    return response()->json([
-                        'status' => 409,
-                        'message' => 'Ya existe un acceso compartido al documento para el usuario o grupo seleccionado'        
-                    ], 409);
-                }
             }
 
             $documentSharedAccess->update($validatedData);
@@ -320,8 +287,8 @@ class DocumentSharedAccessController extends Controller
      */
     private function setDocumentSharedAccessableFields(array $validatedData, Request $request)
     {
-        if ($request->isMethod('post') && !isset($validatedData['access_mode_id'])){
-                $validatedData['access_mode_id'] = 1;
+        if (!isset($validatedData['access_mode_id'])) {
+            $validatedData['access_mode_id'] = 1;
         }
         if (isset($validatedData['resource_id'])) {
             $validatedData['document_shared_accessable_id'] = $validatedData['resource_id'];

--- a/api/app/Http/Requests/UpdateDocumentSharedAccessRequest.php
+++ b/api/app/Http/Requests/UpdateDocumentSharedAccessRequest.php
@@ -26,15 +26,8 @@ class UpdateDocumentSharedAccessRequest extends FormRequest
      */
     public function rules()
     {
-        $rules = [
-            'document_id' => 'sometimes|numeric|exists:documents,id',
-            'access_mode_id' => 'sometimes|numeric|exists:access_modes,id'
+        return [
+            'access_mode_id' => 'sometimes|numeric|exists:access_modes,id',
         ];
-        if ($this->input('resource_type') === 'group') {
-            $rules['resource_id'] = 'sometimes|numeric|exists:groups,id';
-        } else {
-            $rules['resource_id'] = 'sometimes|numeric|exists:redacta_users,id';
-        }
-        return $rules;
     }
 }

--- a/api/app/Models/DocumentSharedAccess.php
+++ b/api/app/Models/DocumentSharedAccess.php
@@ -15,6 +15,7 @@ class DocumentSharedAccess extends Model
         'access_mode_id',
         'document_shared_accessable_type',
         'document_shared_accessable_id',
+        'shared_by'
     ];
 
     protected $hidden = ['document_shared_accessable_type', 'document_shared_accessable_id'];
@@ -44,5 +45,9 @@ class DocumentSharedAccess extends Model
 
     public function getResourceIdAttribute() {
         return $this->attributes['document_shared_accessable_id'];
+    }
+
+    public function sharedBy() {
+        return $this->belongsTo(RedactaUser::class);
     }
 }

--- a/api/database/migrations/2025_08_02_114428_alter_table_documents_shared_accesses.php
+++ b/api/database/migrations/2025_08_02_114428_alter_table_documents_shared_accesses.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('documents_shared_accesses', function (Blueprint $table) {
+            $table->bigInteger('shared_by')->unsigned()->nullable();
+            $table->foreign('shared_by')->references('id')->on('redacta_users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('documents_shared_accesses', function (Blueprint $table) {
+            $table->dropForeign(['shared_by']);
+            $table->dropColumn('shared_by');
+        });
+    }
+};


### PR DESCRIPTION
This pull request makes the following changes regarding to the 'documents shared accesses' resource:

* To simplify the implementation of document shared access update operation, from now on only 'access mode' value can be modified.
* It has been added a new column to 'documents_shared_access' table, which stores the id of the user who shared the document access being saved