### PR TITLE
(api) Rename field added in PR #74

### DIFF
--- a/api/app/Http/Controllers/DocumentSharedAccessController.php
+++ b/api/app/Http/Controllers/DocumentSharedAccessController.php
@@ -95,7 +95,7 @@ class DocumentSharedAccessController extends Controller
                 ], 409);
             }
             
-            $validatedData['shared_by'] = $request->user()->id;
+            $validatedData['redacta_user_id'] = $request->user()->id;
             $documentSharedAccess = DocumentSharedAccess::create($validatedData);
 
             // Notify the user or group members about the shared access

--- a/api/app/Models/DocumentSharedAccess.php
+++ b/api/app/Models/DocumentSharedAccess.php
@@ -15,7 +15,7 @@ class DocumentSharedAccess extends Model
         'access_mode_id',
         'document_shared_accessable_type',
         'document_shared_accessable_id',
-        'shared_by'
+        'redacta_user_id',
     ];
 
     protected $hidden = ['document_shared_accessable_type', 'document_shared_accessable_id'];
@@ -47,7 +47,7 @@ class DocumentSharedAccess extends Model
         return $this->attributes['document_shared_accessable_id'];
     }
 
-    public function sharedBy() {
+    public function redactaUser() {
         return $this->belongsTo(RedactaUser::class);
     }
 }

--- a/api/database/migrations/2025_08_02_114428_alter_table_documents_shared_accesses.php
+++ b/api/database/migrations/2025_08_02_114428_alter_table_documents_shared_accesses.php
@@ -14,8 +14,8 @@ return new class extends Migration
     public function up()
     {
         Schema::table('documents_shared_accesses', function (Blueprint $table) {
-            $table->bigInteger('shared_by')->unsigned()->nullable();
-            $table->foreign('shared_by')->references('id')->on('redacta_users');
+            $table->bigInteger('redacta_user_id')->unsigned()->nullable();
+            $table->foreign('redacta_user_id')->references('id')->on('redacta_users');
         });
     }
 
@@ -27,8 +27,8 @@ return new class extends Migration
     public function down()
     {
         Schema::table('documents_shared_accesses', function (Blueprint $table) {
-            $table->dropForeign(['shared_by']);
-            $table->dropColumn('shared_by');
+            $table->dropForeign(['redacta_user_id']);
+            $table->dropColumn('redacta_user_id');
         });
     }
 };


### PR DESCRIPTION
This pull request renames the 'shared_by' column (added in PR #74) from 'documents_shared_accesses' table to 'redacta_user_id'