### PR TITLE
(api) Add 'label' column to 'roles' table

### DIFF
--- a/api/database/migrations/2025_08_26_153634_alter_roles_table.php
+++ b/api/database/migrations/2025_08_26_153634_alter_roles_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->string('label')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->dropColumn('label');
+        });
+    }
+};


### PR DESCRIPTION
This PR adds the 'label' column to the 'roles' table, that represents the label of the role which will be displayed in the UI.