### PR TITLE
(api) Signup invitations

### DIFF
--- a/api/app/Http/Controllers/AuthenticationController.php
+++ b/api/app/Http/Controllers/AuthenticationController.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use App\Http\Requests\StoreRedactaUserRequest;
+use App\Models\SignupInvitation;
+use Illuminate\Support\Facades\Mail;
+
 
 class AuthenticationController extends Controller
 {
@@ -18,14 +21,28 @@ class AuthenticationController extends Controller
      */
     public function register (StoreRedactaUserRequest $request)
     {
-        $this->authorize('create', User::class);
+        if(!$request->has('token')) {
+            return response()->json([
+                'status' => 400,
+                'message' => 'Token is required'
+            ], 400);
+        }
+        $invitation = SignupInvitation::where('token', $request->get('token'))->first();
+        if (!$invitation || !$invitation->isValid()) {
+            return response()->json([
+                'status' => 400,
+                'message' => 'Invalid token'
+            ], 400);
+        }
+        $validatedData = $request->validated();
         $user = User::create([
-            'name' => $request->name,
-            'last_name' => $request->last_name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'name' => $validatedData['name'],
+            'last_name' => $validatedData['last_name'],
+            'email' => $validatedData['email'],
+            'password' => Hash::make($validatedData['password']),
         ]);
-        $user->assignRole($request->role);
+        $user->assignRole('editor');
+        $invitation->markAsUsed();
         return response()->json([
             'status' => 201,
             'message' => 'OK',
@@ -58,6 +75,28 @@ class AuthenticationController extends Controller
                 'username' => $user->name.' '.$user->last_name,
                 'redacta_user_id' => $user->id,
                 'role' => $user->roles->pluck('name')->first()
+            ]
+        ], 200);
+    }
+
+    /**
+     * Validate sign up invitation token
+     * 
+     */
+    public function validateSignupInvitation(Request $request) {
+        if (!$request->has('token')) {
+            return response()->json([
+                'status' => 400,
+                'message' => 'Token is required'
+            ], 400);
+        }
+        $invitation = SignupInvitation::where('token', $request->get('token'))->first();
+        $isValid = $invitation && $invitation->isValid();
+        return response()->json([
+            'status' => 200,
+            'message' => 'OK',
+            'data' => [
+                'is_valid' => $isValid
             ]
         ], 200);
     }

--- a/api/app/Http/Controllers/SignupInvitationController.php
+++ b/api/app/Http/Controllers/SignupInvitationController.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreSignupInvitationRequest;
+use App\Http\Requests\UpdateSignupInvitationRequest;
+use App\Models\SignupInvitation;
+use Illuminate\Support\Str;
+use Illuminate\Http\Request;
+use App\Models\RedactaUser;
+
+class SignupInvitationController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $this->authorize('viewAny', SignupInvitation::class);
+        if ($request->has('token')) {
+            $query = SignupInvitation::where('token', $request->query('token'));
+        } else {
+            $query = SignupInvitation::query();
+        }
+        $invitations = $query->with('redactaUser')->get();
+        if ($request->has('expired')) {
+            if (!$request->boolean('expired')) {
+                $invitations = $invitations->where(function ($invitation) {
+                    return $invitation->isValid();
+                });
+            } else {
+                $invitations = $invitations->where(function ($invitation) {
+                    return !$invitation->isValid();
+                });
+            }
+        }
+        return response()->json([
+            'status' => 200,
+            'message' => 'OK',
+            'data' => $invitations
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \App\Http\Requests\StoreSignupInvitationRequest  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StoreSignupInvitationRequest $request)
+    {
+        $this->authorize('create', SignupInvitation::class);
+        $validatedData = $request->validated();
+        //Check if there's a valid invitation for this email
+        $existingInvitation = SignupInvitation::where('email', $validatedData['email'])->first();
+        if ($existingInvitation && $existingInvitation->isValid()) {
+            return response()->json([
+                'status' => 400,
+                'message' => 'An active invitation for this email already exists'
+            ], 400);
+        }
+        //Check if the email is already registered
+        if (RedactaUser::where('email', $validatedData['email'])->exists()) {
+            return response()->json([
+                'status' => 400,
+                'message' => 'This email is already registered'
+            ], 400);
+        }
+        $validatedData['redacta_user_id'] = $request->user()->id;
+        $validatedData['token'] = Str::uuid()->toString();
+        $signupInvitation = SignupInvitation::create($validatedData);
+        return response()->json([
+            'status' => 201,
+            'message' => 'OK',
+            'data' => $signupInvitation
+        ], 201);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\SignupInvitation  $signupInvitation
+     * @return \Illuminate\Http\Response
+     */
+    public function show(SignupInvitation $signupInvitation)
+    {
+        $this->authorize('view', $signupInvitation);
+        return response()->json([
+            'status' => 200,
+            'message' => 'OK',
+            'data' => $signupInvitation          
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\SignupInvitation  $signupInvitation
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(SignupInvitation $signupInvitation)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \App\Http\Requests\UpdateSignupInvitationRequest  $request
+     * @param  \App\Models\SignupInvitation  $signupInvitation
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UpdateSignupInvitationRequest $request, SignupInvitation $signupInvitation)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\SignupInvitation  $signupInvitation
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(SignupInvitation $signupInvitation)
+    {
+        $this->authorize('delete', $signupInvitation);
+        $signupInvitation->delete();
+        return response()->json([
+            'status' => 200,
+            'message' => 'OK'
+        ]);
+    }
+}

--- a/api/app/Http/Requests/StoreRedactaUserRequest.php
+++ b/api/app/Http/Requests/StoreRedactaUserRequest.php
@@ -28,7 +28,6 @@ class StoreRedactaUserRequest extends FormRequest
             'last_name' => 'required|string|max:255',        
             'email' => 'required|email|unique:redacta_users',              
             'password' => 'required|confirmed|min:8',
-            'role' => 'required|string|in:super_admin,local_admin,editor'
         ];
     }
 }

--- a/api/app/Http/Requests/StoreSignupInvitationRequest.php
+++ b/api/app/Http/Requests/StoreSignupInvitationRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSignupInvitationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'email' => 'required|email',
+            //'expires_at' => 'required|date|after:now'
+        ];
+    }
+}

--- a/api/app/Http/Requests/UpdateSignupInvitationRequest.php
+++ b/api/app/Http/Requests/UpdateSignupInvitationRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSignupInvitationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'token' => 'required|string',
+            'password' => 'required|string|min:8|confirmed'
+        ];
+    }
+}

--- a/api/app/Mail/SignupInvitation.php
+++ b/api/app/Mail/SignupInvitation.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use App\Models\SignupInvitation as SignupInvitationModel;
+
+class SignupInvitation extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct(private SignupInvitationModel $invitation)
+    {
+    }
+
+    /**
+     * Get the message envelope.
+     *
+     * @return \Illuminate\Mail\Mailables\Envelope
+     */
+    public function envelope()
+    {
+        return new Envelope(
+            subject: 'Confirm Signup',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     *
+     * @return \Illuminate\Mail\Mailables\Content
+     */
+    public function content()
+    {
+        return new Content(
+            view: 'view.emails.signup-invitation',
+            with: [
+                'invitation' => $this->invitation,
+                'url' => env('APP_URL').'/signup?token='.$this->invitation->token
+            ]
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array
+     */
+    public function attachments()
+    {
+        return [];
+    }
+}

--- a/api/app/Models/SignupInvitation.php
+++ b/api/app/Models/SignupInvitation.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SignupInvitation extends Model
+{
+    use HasFactory;
+    protected $fillable = [
+        'redacta_user_id',
+        'token', 
+        'email',  
+    ];
+
+    public function redactaUser()
+    {
+        return $this->belongsTo(RedactaUser::class, 'redacta_user_id');
+    }
+
+    public function markAsUsed()
+    {
+        $this->used_at = now();
+        $this->save();
+    }
+
+    public function isValid() {
+        if ($this->used_at !== null || $this->created_at->diffInHours(now()) > 24) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/api/app/Policies/SignupInvitationPolicy.php
+++ b/api/app/Policies/SignupInvitationPolicy.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\RedactaUser;
+use App\Models\SignupInvitation;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class SignupInvitationPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     *
+     * @param  \App\Models\RedactaUser  $redactaUser
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function viewAny(RedactaUser $redactaUser)
+    {
+        return $redactaUser->hasAnyRole(['super_admin', 'local_admin']);
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \App\Models\RedactaUser  $redactaUser
+     * @param  \App\Models\SignupInvitation  $signupInvitation
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view(RedactaUser $redactaUser, SignupInvitation $signupInvitation)
+    {
+        return $redactaUser->hasAnyRole(['super_admin', 'local_admin']);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param  \App\Models\RedactaUser  $redactaUser
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function create(RedactaUser $redactaUser)
+    {
+        return $redactaUser->hasAnyRole(['super_admin', 'local_admin']);
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\Models\RedactaUser  $redactaUser
+     * @param  \App\Models\SignupInvitation  $signupInvitation
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(RedactaUser $redactaUser, SignupInvitation $signupInvitation)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\RedactaUser  $redactaUser
+     * @param  \App\Models\SignupInvitation  $signupInvitation
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function delete(RedactaUser $redactaUser, SignupInvitation $signupInvitation)
+    {
+        return $redactaUser->hasAnyRole(['super_admin', 'local_admin']);
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     *
+     * @param  \App\Models\RedactaUser  $redactaUser
+     * @param  \App\Models\SignupInvitation  $signupInvitation
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function restore(RedactaUser $redactaUser, SignupInvitation $signupInvitation)
+    {
+        return $redactaUser->hasAnyRole(['super_admin', 'local_admin']);
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     *
+     * @param  \App\Models\RedactaUser  $redactaUser
+     * @param  \App\Models\SignupInvitation  $signupInvitation
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function forceDelete(RedactaUser $redactaUser, SignupInvitation $signupInvitation)
+    {
+        return $redactaUser->hasAnyRole(['super_admin', 'local_admin']);
+    }
+}

--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -26,6 +26,7 @@ class AuthServiceProvider extends ServiceProvider
         'App\Models\Group' => 'App\Policies\GroupPolicy',
         'App\Models\GroupMembership' => 'App\Policies\GroupMembershipPolicy',
         'App\Models\Stamp' => 'App\Policies\StampPolicy',
+        'App\Models\SignupInvitation' => 'App\Policies\SignupInvitationPolicy',
     ];
 
     /**

--- a/api/database/migrations/2025_09_17_134514_create_signup_invitations_table.php
+++ b/api/database/migrations/2025_09_17_134514_create_signup_invitations_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('signup_invitations', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            //User who sent the invitation
+            $table->foreignId('redacta_user_id')->constrained('redacta_users');
+            //Email of the invitation recipient
+            $table->string('email')->unique();
+            //Uuid as unique token for the invitation
+            $table->string('token', 64)->unique();
+            //Timestamp of when the invitation was used
+            $table->timestamp('used_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('signup_invitations');
+    }
+};

--- a/api/resources/views/emails/signup-invitation.php
+++ b/api/resources/views/emails/signup-invitation.php
@@ -1,0 +1,5 @@
+<strong>Hola {{$invitation->redactaUser->name}}</strong><br><br>
+Te hemos enviado una invitación para unirte a nuestra plataforma. Haz clic en el siguiente enlace para confirmar tu registro:<br><br>
+<a href="{{$url}}">{{$url}}</a>
+<br><br>
+Si no solicitaste esta invitación, puedes ignorar este correo electrónico.<br><br>

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -57,3 +57,4 @@ Route::middleware('auth:sanctum')->group(function () {
   Route::post('/register', [AuthenticationController::class, 'register']);
 });
 Route::post('/login', [AuthenticationController::class, 'login']);
+Route::get('/validate_signup_invitation', [AuthenticationController::class, 'validateSignUpInvitation']);

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -19,7 +19,7 @@ use App\Http\Controllers\VisibilityLevelController;
 use App\Http\Controllers\AccessModeController;
 use App\Http\Controllers\GroupController;
 use App\Http\Controllers\GroupMembershipController;
-
+use App\Http\Controllers\SignupInvitationController;
 
 /*
 |--------------------------------------------------------------------------
@@ -53,7 +53,7 @@ Route::middleware('auth:sanctum')->group(function () {
   Route::apiResource('groups', GroupController::class);
   Route::apiResource('group_memberships', GroupMembershipController::class);
   Route::get('/export_anexo/{id}', [DocumentController::class, 'exportAnexo']);
+  Route::apiResource('signup_invitations', SignupInvitationController::class);
   Route::post('/register', [AuthenticationController::class, 'register']);
 });
 Route::post('/login', [AuthenticationController::class, 'login']);
-


### PR DESCRIPTION
This PR implements a new method for users signup. In order to register a new user, any admin user must generate an invitation which is sent via email. The new user receives the mail and opens the link it contains. This link allows the new user to create a new profile.
The invitation expires in 24 hs since its creation.
To implement the process described above, this PR does the following changes in the api side:
- adds the 'SignupInvitation' api resource
- updates the 'AuthenticationController', modifying the 'register' method and adding a method to verify if an invitation is valid