### PR TITLE
(api) Add 'reset password' functionality

### DIFF
--- a/api/app/Http/Controllers/AuthenticationController.php
+++ b/api/app/Http/Controllers/AuthenticationController.php
@@ -11,6 +11,10 @@ use Illuminate\Support\Facades\Validator;
 use App\Http\Requests\StoreRedactaUserRequest;
 use App\Models\SignupInvitation;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use App\Models\PasswordReset;
+use App\Mail\PasswordResetMail;
+use Carbon\Carbon;
 
 
 class AuthenticationController extends Controller
@@ -109,6 +113,51 @@ class AuthenticationController extends Controller
     public function logout (Request $request)
     {
         $request->user()->currentAccessToken()->delete();
+    }
+
+    public function forgotPassword(Request $request)
+    {
+        $request->validate(['email' => 'required|email']);
+        $email = $request->input('email');
+        $user = User::where('email', $email)->first();
+        if (!$user) {
+            return response()->json(['status' => 400, 'message' => 'El mail ingresado no está asociado a ninguna cuenta'], 400);
+        }
+        $token = Str::random(64);
+        $passwordReset = PasswordReset::create([
+            'email' => $email,
+            'token' => $token, 
+            'created_at' => now()
+        ]);
+        $frontendBase = env('APP_URL', config('app.app_url', ''));
+        $link = $frontendBase . '/reset-password?token=' . $token;
+        Mail::to($email)->send(new PasswordResetMail($user, $link, $passwordReset->created_at->addMinutes(60)->format('d/m/Y H:i')));
+        return response()->json(['status' => '200', 'message' => 'OK']);
+    }
+
+    public function resetPassword(Request $request)
+    {
+        $request->validate([
+            'token' => 'required|string',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+        $token = $request->input('token');
+        $passwordReset = PasswordReset::where('token', $token)
+            ->where('used', false)
+            ->first();
+        if (!$passwordReset) {
+            return response()->json(['status' => 400, 'message' => 'El link es inválido'], 400);
+        }
+        $created = Carbon::parse($passwordReset->created_at);
+        if ($created->addMinutes(60)->isPast()) {
+            return response()->json(['status' => 400, 'message' => 'El link ha expirado'], 400);
+        }
+        $user = User::where('email', $passwordReset->email)->first();
+        $user->password = Hash::make($request->input('password'));
+        $user->save();
+        $passwordReset->used = true;
+        $passwordReset->save();
+        return response()->json(['status' => 200, 'message' => 'OK']);
     }
 }
 

--- a/api/app/Mail/PasswordResetMail.php
+++ b/api/app/Mail/PasswordResetMail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use App\Models\RedactaUser;
+
+class PasswordResetMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $user;
+    public $link;
+
+    public function __construct(RedactaUser $user, string $link, string $expiration)
+    {
+        $this->user = $user;
+        $this->link = $link;
+        $this->expiration = $expiration;
+    }
+
+    public function build()
+    {
+        return $this->subject('Restablecer contraseña de su cuenta en RedActa')
+                    ->view('emails.password-reset')
+                    ->with([
+                        'name' => $this->user->name,
+                        'link' => $this->link,
+                        'expiration' => $this->expiration,
+                    ]);
+    }
+}

--- a/api/app/Models/PasswordReset.php
+++ b/api/app/Models/PasswordReset.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PasswordReset extends Model
+{
+    protected $table = 'password_resets';
+    public $timestamps = false;
+    protected $fillable = ['email', 'token', 'used', 'created_at'];
+}

--- a/api/app/Models/PasswordReset.php
+++ b/api/app/Models/PasswordReset.php
@@ -9,4 +9,5 @@ class PasswordReset extends Model
     protected $table = 'password_resets';
     public $timestamps = false;
     protected $fillable = ['email', 'token', 'used', 'created_at'];
+    protected $primaryKey = 'token';
 }

--- a/api/database/migrations/2025_12_11_000001_add_used_to_password_resets_table.php
+++ b/api/database/migrations/2025_12_11_000001_add_used_to_password_resets_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('password_resets', function (Blueprint $table) {
+            $table->boolean('used')->default(false)->after('token')->index();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('password_resets', function (Blueprint $table) {
+            $table->dropColumn('used');
+        });
+    }
+};

--- a/api/resources/views/emails/password-reset.blade.php
+++ b/api/resources/views/emails/password-reset.blade.php
@@ -1,0 +1,10 @@
+<html>
+  <body>
+    <p>Hola {{ $name }},</p>
+    <p>Recibimos una solicitud para restablecer tu contraseña. Haz clic en el siguiente enlace para crear una nueva contraseña:</p>
+    <p><a href="{{ $link }}">{{ $link }}</a></p>
+    <p>Este enlace expirará el {{ $expiration }}.</p>
+    <p>Si no solicitaste este cambio, ignora este correo.</p>
+    <p>Saludos</p>
+  </body>
+</html>

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -62,3 +62,7 @@ Route::middleware('auth:sanctum')->group(function () {
 });
 Route::post('/login', [AuthenticationController::class, 'login']);
 Route::get('/validate_signup_invitation', [AuthenticationController::class, 'validateSignUpInvitation']);
+
+// Rutas públicas para restablecer contraseña
+Route::post('/password/forgot', [AuthenticationController::class, 'forgotPassword']);
+Route::post('/password/reset', [AuthenticationController::class, 'resetPassword']);


### PR DESCRIPTION
This PR implements the 'reset password' functionality, which allows users to recover their password in case they have forgotten it. When a 'reset password' request is received by the backend, a unique link is generated and is sent via email to the user who made the request. The link allows the user to set a new password and is valid for maximun 1 hour after its creation. 