### PR TITLE
(front) Add forgot and reset password pages

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -4,6 +4,8 @@ import { AuthGuard } from './auth/auth-core/auth.guard';
 
 const routes: Routes = [
   { path: 'login', loadChildren: () => import('./auth/login/login.module').then(m => m.LoginModule) },
+  { path: 'forgot-password', loadChildren: () => import('./auth/forgot-password/forgot-password.module').then(m => m.ForgotPasswordModule) },
+  { path: 'reset-password', loadChildren: () => import('./auth/reset-password/reset-password.module').then(m => m.ResetPasswordModule) },
   { path: '', loadChildren: () => import('./panel/panel.module').then(m => m.PanelModule), canActivate: [AuthGuard] },
   { path: '**', redirectTo: '' }
 ];

--- a/frontend/src/app/auth/forgot-password/forgot-password-routing.module.ts
+++ b/frontend/src/app/auth/forgot-password/forgot-password-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ForgotPasswordComponent } from './forgot-password.component';
+
+const routes: Routes = [
+  { path: '', component: ForgotPasswordComponent }, 
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ForgotPasswordRoutingModule {}

--- a/frontend/src/app/auth/forgot-password/forgot-password.component.html
+++ b/frontend/src/app/auth/forgot-password/forgot-password.component.html
@@ -1,0 +1,29 @@
+<nb-layout>
+  <nb-layout-column class="d-flex align-items-center justify-content-center"> 
+    <nb-card>
+      <nb-card-header>Reestablecer contraseña</nb-card-header>
+      <nb-card-body>
+        <ng-container *ngIf="!loading">
+          <form *ngIf="!success" [formGroup]="form" (ngSubmit)="submit()">
+            <div class="form-group">
+              <label>Email</label>
+              <input nbInput fullWidth formControlName="email" placeholder="Tu email" (input)="error = ''">
+              <div *ngIf="form.get('email')?.invalid && form.get('email')?.touched" class="text-danger">
+                Email inválido.
+              </div>
+            </div>
+            <div class="d-flex justify-content-end" style="gap:.5rem;">
+              <button nbButton fullWidth status="primary" type="submit" [disabled]="form.invalid">Reestablecer contraseña</button>
+            </div>
+          </form>
+          <div class="text-center" *ngIf="success">
+            <p class="text-success">Se envió un enlace al email ingresado con los pasos para restablecer la contraseña.</p>
+          </div>
+          <div class="text-danger mt-2" *ngIf="error">{{ error }}</div>
+          <p class="text-center mt-4"><a routerLink="/login">Volver al login</a></p>
+        </ng-container>
+        <nb-spinner *ngIf="loading"></nb-spinner>
+      </nb-card-body>
+    </nb-card>
+  </nb-layout-column>
+</nb-layout>

--- a/frontend/src/app/auth/forgot-password/forgot-password.component.ts
+++ b/frontend/src/app/auth/forgot-password/forgot-password.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { AuthService } from '../auth-core/auth.service';
+import { finalize } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-forgot-password',
+  templateUrl: './forgot-password.component.html',
+})
+export class ForgotPasswordComponent {
+  form: FormGroup;
+  loading = false;
+  success = false;
+  error = '';
+
+  constructor(private fb: FormBuilder, private auth: AuthService) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]]
+    });
+  }
+
+  submit() {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.loading = true;
+    this.error = '';
+    this.auth.forgotPassword(this.form.get('email')!.value)
+      .pipe(finalize(()=> this.loading = false))
+      .subscribe({
+        next: () => {
+          this.success = true;
+        },
+        error: (e) => {
+          this.error = e?.error?.message || 'Ha habido un error. Intente nuevamente.';
+        }
+      });
+  }
+}

--- a/frontend/src/app/auth/forgot-password/forgot-password.module.ts
+++ b/frontend/src/app/auth/forgot-password/forgot-password.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NbCardModule, NbInputModule, NbButtonModule, NbIconModule, NbSpinnerModule, NbLayoutModule } from '@nebular/theme';
+import { ForgotPasswordComponent } from './forgot-password.component';
+import { ForgotPasswordRoutingModule } from './forgot-password-routing.module';
+
+@NgModule({
+  declarations: [ForgotPasswordComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    NbCardModule,
+    NbLayoutModule,
+    NbInputModule,
+    NbButtonModule,
+    NbSpinnerModule,
+    NbIconModule,
+    ForgotPasswordRoutingModule
+  ]
+})
+export class ForgotPasswordModule {}

--- a/frontend/src/app/auth/login/login.component.html
+++ b/frontend/src/app/auth/login/login.component.html
@@ -11,6 +11,7 @@
           <div class="form-group">
             <label class="label" for="password">Contraseña</label>
             <input type="password" nbInput fullWidth id="password" formControlName="password" name="password" placeholder="Ingrese contraseña">
+            <a class="forgot-password-link" routerLink="/forgot-password">Olvidé mi contraseña</a>
           </div>
           <button fullWidth [nbSpinner]="loading" nbSpinnerStatus="primary" status="primary" nbButton type="submit" [disabled]="!loginForm.valid || loading">
             <ng-container *ngIf="!loading">Iniciar sesión</ng-container> 

--- a/frontend/src/app/auth/login/login.component.scss
+++ b/frontend/src/app/auth/login/login.component.scss
@@ -1,3 +1,8 @@
 button {
     height: 3rem;
 }
+
+.forgot-password-link {
+    display: block;
+    margin-top: 0.5rem;
+}

--- a/frontend/src/app/auth/reset-password/reset-password-routing.module.ts
+++ b/frontend/src/app/auth/reset-password/reset-password-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ResetPasswordComponent } from './reset-password.component';
+
+const routes: Routes = [
+  { path: '', component: ResetPasswordComponent } // /reset-password
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ResetPasswordRoutingModule {}

--- a/frontend/src/app/auth/reset-password/reset-password.component.html
+++ b/frontend/src/app/auth/reset-password/reset-password.component.html
@@ -1,0 +1,50 @@
+<nb-layout>
+  <nb-layout-column class="d-flex align-items-center justify-content-center"> 
+    <nb-card>
+        <nb-card-header>Restablecer contraseña</nb-card-header>
+            <nb-card-body>
+                <ng-container *ngIf="!loading">
+                    <form *ngIf="token && !success" [formGroup]="form" (ngSubmit)="submit()">
+                        <div class="form-group">
+                            <label class="label">Nueva contraseña</label>
+                            <nb-form-field>
+                              <input [type]="getPasswordFieldType('password')" nbInput fullWidth formControlName="password" placeholder="Contraseña">
+                              <button nbSuffix nbButton ghost (click)="togglePasswordVisibility('password')" type="button">
+                                <nb-icon [icon]="showPassword ? 'eye-outline' : 'eye-off-2-outline'"
+                                         pack="eva"
+                                         [attr.aria-label]="showPassword ? 'hide password' : 'show password'">
+                                </nb-icon>
+                              </button>
+                            </nb-form-field>
+                            <div *ngIf="form.get('password')?.invalid && form.get('password')?.touched" class="text-danger p-1">
+                                Mínimo 8 caracteres.
+                            </div>
+                        </div>
+    
+                        <div class="form-group">
+                            <label class="label">Confirmar contraseña</label>
+                            <nb-form-field>
+                              <input [type]="getPasswordFieldType('passwordConfirmation')" nbInput fullWidth formControlName="passwordConfirmation" placeholder="Confirmar contraseña">
+                              <button nbSuffix nbButton ghost (click)="togglePasswordVisibility('passwordConfirmation')" type="button">
+                                <nb-icon [icon]="showPasswordConfirmation ? 'eye-outline' : 'eye-off-2-outline'"
+                                         pack="eva"
+                                         [attr.aria-label]="showPasswordConfirmation ? 'hide password' : 'show password'">
+                                </nb-icon>
+                              </button>
+                            </nb-form-field>
+                            <div *ngIf="form.errors?.['passwordMismatch'] && form.get('passwordConfirmation')?.touched" class="text-danger p-1">
+                                Las contraseñas no coinciden.
+                            </div>
+                        </div>
+                        <div class="d-flex justify-content-end">
+                            <button nbButton fullWidth status="primary" type="submit" [disabled]="form.invalid">Cambiar</button>
+                        </div>
+                    </form>
+                    <div class="text-success" *ngIf="success">Contraseña cambiada. Redirigiendo a login...</div>
+                    <div class="text-danger text-center py-2" *ngIf="error">{{ error }}</div>
+                </ng-container>
+                <div class="mt-3" *ngIf="loading"><nb-spinner></nb-spinner></div>
+            </nb-card-body>
+        </nb-card>
+  </nb-layout-column>
+</nb-layout>

--- a/frontend/src/app/auth/reset-password/reset-password.component.ts
+++ b/frontend/src/app/auth/reset-password/reset-password.component.ts
@@ -1,0 +1,73 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AuthService } from '../auth-core/auth.service';
+import { finalize } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-reset-password',
+  templateUrl: './reset-password.component.html'
+})
+export class ResetPasswordComponent implements OnInit {
+  form!: FormGroup;
+  token: string | null = null;
+  loading = false;
+  success = false;
+  error = '';
+  showPassword = false;
+  showPasswordConfirmation = false;
+
+  constructor(
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    private auth: AuthService,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      passwordConfirmation: ['', Validators.required]
+    }, { validators: this.passwordsMatch });
+
+    this.token = this.route.snapshot.queryParamMap.get('token');
+    if (!this.token) {
+      this.error = 'Token no provisto.';
+    }
+  }
+
+  passwordsMatch(group: FormGroup) {
+    const p = group.get('password')?.value;
+    const pc = group.get('passwordConfirmation')?.value;
+    return p === pc ? null : { passwordMismatch: true };
+  }
+
+  getPasswordFieldType(field: string) {
+    const showField = field === 'password' ? this.showPassword : this.showPasswordConfirmation;
+    return showField ? 'text' : 'password';
+  }
+
+  togglePasswordVisibility(field: string) {
+    if (field === 'password') {
+      this.showPassword = !this.showPassword;
+    } else {
+      this.showPasswordConfirmation = !this.showPasswordConfirmation;
+    }
+  }
+
+  submit() {
+    if (!this.token) return;
+    this.loading = true;
+    this.auth.resetPassword(this.token, this.form.get('password')!.value, this.form.get('passwordConfirmation')!.value)
+      .pipe(finalize(()=> this.loading = false))
+      .subscribe({
+        next: () => {
+          this.success = true;
+          setTimeout(() => this.router.navigate(['/login']), 200);
+        },
+        error: (e) => {
+          this.error = e?.error?.message || 'Error al restablecer la contraseña';
+        }
+      });
+  }
+}

--- a/frontend/src/app/auth/reset-password/reset-password.module.ts
+++ b/frontend/src/app/auth/reset-password/reset-password.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ResetPasswordRoutingModule } from './reset-password-routing.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { NbCardModule, NbInputModule, NbButtonModule, NbSpinnerModule, NbLayoutModule, NbIconModule, NbFormFieldModule } from '@nebular/theme';
+import { ResetPasswordComponent } from './reset-password.component';
+
+@NgModule({
+  declarations: [ResetPasswordComponent],
+  imports: [
+    CommonModule,
+    ResetPasswordRoutingModule,
+    ReactiveFormsModule,
+    NbCardModule, NbInputModule, NbButtonModule, NbSpinnerModule, NbLayoutModule, NbIconModule, NbFormFieldModule
+  ]
+})
+export class ResetPasswordModule {}


### PR DESCRIPTION
This PR implements the forgot and reset password pages:
* In 'forgot password', user can request a password reset, indicating the email address whose account is linked to. 
* In 'reset password', the user can create a new password.  This page can be accessed from the private link that has been sent to the user by email.